### PR TITLE
Fix cancel match permissions and add match found DMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+*.egg-info/
+dist/
+build/
+.env

--- a/core/ButtonManager.py
+++ b/core/ButtonManager.py
@@ -63,6 +63,7 @@ def start_queue_button(guild_id: str, inter: Interaction, autopick: bool):
   record.team2_votes = list()
   record.cancel_votes = list()
   QueueManager.update_queue_view(record, embeds=embed, components=component, inter=inter)
+  QueueManager.send_match_found_dms(inter, record)
   if len(record.team_1) == 4 and len(record.team_2) == 4:
     print("Moving members to team queue")
   for user in record.team_1:

--- a/core/QueueManager.py
+++ b/core/QueueManager.py
@@ -314,8 +314,14 @@ def generate_match_done_embed(team1, team2, guild_id, queue_record: QueueRecord)
 def cancel_match(inter: Interaction, queue_id: str):
     response = queue_dao.get_queue(guild_id=inter.guild_id, queue_id=queue_id)
 
-    if len(response.team_1) == 4 and len(response.team_2) == 4:
+    is_match_ready = len(response.team_1) == 4 and len(response.team_2) == 4
+
+    if is_match_ready:
         if inter.user_id not in response.team_1 and inter.user_id not in response.team_2:
+            return None
+    else:
+        # Pick phase: only players in the queue can cancel
+        if inter.user_id not in response.queue:
             return None
 
     if inter.user_id not in response.cancel_votes:
@@ -330,7 +336,12 @@ def cancel_match(inter: Interaction, queue_id: str):
     resp = queue_dao.put_queue(response)
 
     if resp is not None:
-        if len(response.cancel_votes) > 4:
+        # Match ready: 5 votes (half + 1); pick phase: half the queue size
+        if is_match_ready:
+            cancel_threshold = 5
+        else:
+            cancel_threshold = len(response.queue) // 2
+        if len(response.cancel_votes) >= cancel_threshold:
             response = queue_dao.get_queue(guild_id=inter.guild_id, queue_id=queue_id)
             response.clear_queue(reset_expiry=False)
             resp = queue_dao.put_queue(response)

--- a/core/QueueManager.py
+++ b/core/QueueManager.py
@@ -188,6 +188,17 @@ def start_match(inter: Interaction, queue_id: str, autopick: bool):
         return embed, component
     return None
 
+def send_match_found_dms(inter: Interaction, record: QueueRecord) -> None:
+    maps_str = "\n".join(record.maps) if record.maps else "TBD"
+    embed = Embedding(
+        title="⚔️ Match Found!",
+        desc=f"A match has started in **{record.queue_id}**. Captains are picking teams!",
+        color=0x00C853
+    )
+    embed.add_field("Maps", maps_str, inline=False)
+    for player_id in record.queue:
+        inter.send_dm(user_id=player_id, embeds=[embed])
+
 def get_maps(queue_record: QueueRecord):
     if "Variant" in queue_record.queue_id:
         variant_maps = ["Skidrow SND", "Invasion SND", "Terminal SND", "Highrise SND", "Karachi SND"]

--- a/discord_lambda/Interaction.py
+++ b/discord_lambda/Interaction.py
@@ -155,6 +155,20 @@ class Interaction:
         except Exception as e:
             raise Exception(f"Unable to send message: {e}")
 
+    def send_dm(self, user_id: str, content: str = None, embeds: list[Embedding] = None) -> None:
+        try:
+            headers = {'Authorization': f'Bot {os.environ.get("BOT_TOKEN")}'}
+            dm_response = requests.post(
+                'https://discord.com/api/v10/users/@me/channels',
+                json={"recipient_id": user_id},
+                headers=headers
+            )
+            dm_response.raise_for_status()
+            dm_channel_id = dm_response.json()['id']
+            self.send_message(channel_id=dm_channel_id, content=content, embeds=embeds)
+        except Exception as e:
+            print(f"Unable to send DM to user {user_id}: {e}")
+
     def send_file(self, channel_id: str, file_name: str):
         try:
             headers = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,161 @@
+"""Pytest configuration and shared fixtures."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+import sys
+from types import ModuleType
+
+# Mock trueskill and more_itertools before any project imports
+trueskill_mock = ModuleType('trueskill')
+trueskill_mock.TrueSkill = MagicMock()
+trueskill_mock.Rating = MagicMock()
+sys.modules['trueskill'] = trueskill_mock
+
+more_itertools_mock = ModuleType('more_itertools')
+more_itertools_mock.set_partitions = MagicMock(return_value=[])
+sys.modules['more_itertools'] = more_itertools_mock
+
+# Create mock boto3 module structure
+boto3_mock = ModuleType('boto3')
+botocore_mock = ModuleType('botocore')
+botocore_exceptions = ModuleType('botocore.exceptions')
+
+# Add to sys.modules before any imports
+sys.modules['boto3'] = boto3_mock
+sys.modules['boto3.dynamodb'] = ModuleType('boto3.dynamodb')
+sys.modules['boto3.dynamodb.conditions'] = ModuleType('boto3.dynamodb.conditions')
+sys.modules['botocore'] = botocore_mock
+sys.modules['botocore.exceptions'] = botocore_exceptions
+
+# Add mock attributes
+boto3_mock.Session = MagicMock()
+boto3_mock.resource = MagicMock()
+sys.modules['boto3.dynamodb.conditions'].Attr = MagicMock()
+sys.modules['boto3.dynamodb.conditions'].Key = MagicMock()
+botocore_exceptions.ClientError = Exception
+
+from dao.QueueDao import QueueRecord
+from discord_lambda import Interaction
+
+
+@pytest.fixture
+def mock_interaction():
+    """Create a mock Interaction object for testing."""
+    inter = MagicMock(spec=Interaction)
+    inter.guild_id = "guild_123"
+    inter.user_id = "user_456"
+    inter.username = "TestPlayer"
+    inter.custom_id = "join_pre_queue#main"
+    inter.send_response = MagicMock()
+    inter.send_message = MagicMock()
+    inter.edit_response = MagicMock(return_value=["msg_id", "ch_id"])
+    inter.edit_message = MagicMock(return_value=["msg_id", "ch_id"])
+    return inter
+
+
+@pytest.fixture
+def queue_record_waiting():
+    """Create a QueueRecord in Waiting state (no game in progress)."""
+    return QueueRecord(
+        guild_id="guild_123",
+        queue_id="main",
+        team_1=[],
+        team_2=[],
+        queue=["user1", "user2", "user3"],
+        cancel_votes=[],
+        team1_votes=[],
+        team2_votes=[],
+        maps=[],
+        map_set=["Map1", "Map2", "Map3"],
+        version=1,
+        expiry=9999999999,
+        result_channel_id="result_ch",
+        team_1_channel_id="team1_ch",
+        team_2_channel_id="team2_ch",
+        money_queue=False,
+        pre_queue=[],
+    )
+
+
+@pytest.fixture
+def queue_record_picking():
+    """Create a QueueRecord in Picking state (captains assigned, teams being filled)."""
+    return QueueRecord(
+        guild_id="guild_123",
+        queue_id="main",
+        team_1=["cap1"],
+        team_2=["cap2"],
+        queue=["user3", "user4", "user5", "user6", "user7", "user8"],
+        cancel_votes=[],
+        team1_votes=[],
+        team2_votes=[],
+        maps=["Map1"],
+        map_set=["Map1", "Map2", "Map3"],
+        version=2,
+        expiry=9999999999,
+        result_channel_id="result_ch",
+        team_1_channel_id="team1_ch",
+        team_2_channel_id="team2_ch",
+        money_queue=False,
+        pre_queue=[],
+    )
+
+
+@pytest.fixture
+def queue_record_match_ready():
+    """Create a QueueRecord in Match Ready state (game about to start)."""
+    return QueueRecord(
+        guild_id="guild_123",
+        queue_id="main",
+        team_1=["cap1", "user1", "user2", "user3"],
+        team_2=["cap2", "user4", "user5", "user6"],
+        queue=[],
+        cancel_votes=[],
+        team1_votes=[],
+        team2_votes=[],
+        maps=["Map1", "Map2", "Map3"],
+        map_set=["Map1", "Map2", "Map3"],
+        version=3,
+        expiry=9999999999,
+        result_channel_id="result_ch",
+        team_1_channel_id="team1_ch",
+        team_2_channel_id="team2_ch",
+        money_queue=False,
+        pre_queue=[],
+    )
+
+
+def _create_mock_player(player_id="user_456", player_name="TestPlayer"):
+    """Helper to create a properly configured mock player."""
+    player = MagicMock()
+    player.player_id = player_id
+    player.player_name = player_name
+    player.sr = 2000
+    player.get_rating = MagicMock(return_value=2000)
+    player.get_rank_emoji = MagicMock(return_value="🥇")
+    player.get_streak = MagicMock(return_value="")
+    player.delta = "+50"
+    return player
+
+
+@pytest.fixture
+def mock_player_dao(mocker):
+    """Mock PlayerDao for testing."""
+    mock = mocker.patch('core.QueueManager.player_dao')
+
+    # Side effect to create players with correct IDs
+    def get_player_side_effect(guild_id, player_id):
+        return _create_mock_player(player_id=player_id, player_name=f"Player_{player_id}")
+
+    mock.get_player = MagicMock(side_effect=get_player_side_effect)
+    mock.put_player = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def mock_queue_dao(mocker):
+    """Mock QueueDao for testing."""
+    mock = mocker.patch('core.QueueManager.queue_dao')
+    mock.put_queue = MagicMock(return_value=None)
+    mock.get_queue = MagicMock(return_value=None)
+    return mock

--- a/tests/test_cancel_match.py
+++ b/tests/test_cancel_match.py
@@ -1,0 +1,181 @@
+"""Tests for cancel_match permission and threshold logic."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from dao.QueueDao import QueueRecord
+from core.QueueManager import cancel_match
+
+
+def _make_record(team_1=None, team_2=None, queue=None, cancel_votes=None):
+    return QueueRecord(
+        guild_id="guild_123",
+        queue_id="main",
+        team_1=team_1 or [],
+        team_2=team_2 or [],
+        queue=queue or [],
+        cancel_votes=cancel_votes or [],
+        team1_votes=[],
+        team2_votes=[],
+        maps=["Map1", "Map2", "Map3"],
+        map_set=["Map1", "Map2", "Map3"],
+        version=1,
+        expiry=9999999999,
+        result_channel_id="result_ch",
+        team_1_channel_id="team1_ch",
+        team_2_channel_id="team2_ch",
+        money_queue=False,
+        pre_queue=[],
+    )
+
+
+def _make_inter(user_id="voter1"):
+    inter = MagicMock()
+    inter.guild_id = "guild_123"
+    inter.user_id = user_id
+    inter.custom_id = "cancel_match#main"
+    return inter
+
+
+class TestCancelMatchPermissions:
+
+    def test_pick_phase_player_in_queue_can_cancel(self, mock_queue_dao, mock_player_dao):
+        """A player in the queue can vote to cancel during pick phase."""
+        record = _make_record(
+            team_1=["cap1"], team_2=["cap2"],
+            queue=["cap1", "cap2", "p3", "p4", "p5", "p6", "p7", "p8"],
+        )
+        mock_queue_dao.get_queue.return_value = record
+        mock_queue_dao.put_queue.return_value = True
+
+        inter = _make_inter(user_id="p3")
+        result = cancel_match(inter, "main")
+
+        assert result is not None
+        assert "p3" in record.cancel_votes
+
+    def test_pick_phase_outsider_cannot_cancel(self, mock_queue_dao, mock_player_dao):
+        """A player NOT in the queue cannot cancel during pick phase."""
+        record = _make_record(
+            team_1=["cap1"], team_2=["cap2"],
+            queue=["cap1", "cap2", "p3", "p4", "p5", "p6", "p7", "p8"],
+        )
+        mock_queue_dao.get_queue.return_value = record
+
+        inter = _make_inter(user_id="outsider")
+        result = cancel_match(inter, "main")
+
+        assert result is None
+        assert "outsider" not in record.cancel_votes
+
+    def test_match_ready_team_member_can_cancel(self, mock_queue_dao, mock_player_dao):
+        """A player on a team can vote to cancel after teams are full."""
+        record = _make_record(
+            team_1=["p1", "p2", "p3", "p4"],
+            team_2=["p5", "p6", "p7", "p8"],
+        )
+        mock_queue_dao.get_queue.return_value = record
+        mock_queue_dao.put_queue.return_value = True
+
+        inter = _make_inter(user_id="p1")
+        result = cancel_match(inter, "main")
+
+        assert result is not None
+        assert "p1" in record.cancel_votes
+
+    def test_match_ready_outsider_cannot_cancel(self, mock_queue_dao, mock_player_dao):
+        """A player not on either team cannot cancel after teams are full."""
+        record = _make_record(
+            team_1=["p1", "p2", "p3", "p4"],
+            team_2=["p5", "p6", "p7", "p8"],
+        )
+        mock_queue_dao.get_queue.return_value = record
+
+        inter = _make_inter(user_id="outsider")
+        result = cancel_match(inter, "main")
+
+        assert result is None
+        assert "outsider" not in record.cancel_votes
+
+
+class TestCancelMatchThresholds:
+
+    def test_pick_phase_cancels_at_half_queue_size(self, mock_queue_dao, mock_player_dao):
+        """Pick phase cancels when votes reach half the queue size (8 players → 4 votes)."""
+        all_players = ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"]
+        record = _make_record(
+            team_1=["p1"], team_2=["p2"],
+            queue=all_players,
+            cancel_votes=["p1", "p2", "p3"],  # 3 votes already
+        )
+        cleared_record = _make_record()  # empty after clear
+        mock_queue_dao.get_queue.side_effect = [record, cleared_record]
+        mock_queue_dao.put_queue.return_value = True
+
+        inter = _make_inter(user_id="p4")  # 4th vote
+        cancel_match(inter, "main")
+
+        # clear_queue should have been called — put_queue called twice
+        assert mock_queue_dao.put_queue.call_count == 2
+
+    def test_pick_phase_does_not_cancel_at_3_votes(self, mock_queue_dao, mock_player_dao):
+        """Pick phase does NOT cancel at 3 votes."""
+        all_players = ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"]
+        record = _make_record(
+            team_1=["p1"], team_2=["p2"],
+            queue=all_players,
+            cancel_votes=["p1", "p2"],  # 2 votes already
+        )
+        mock_queue_dao.get_queue.return_value = record
+        mock_queue_dao.put_queue.return_value = True
+
+        inter = _make_inter(user_id="p3")  # 3rd vote — not enough
+        cancel_match(inter, "main")
+
+        # put_queue called only once (no second call for clear_queue)
+        assert mock_queue_dao.put_queue.call_count == 1
+
+    def test_match_ready_cancels_at_5_votes(self, mock_queue_dao, mock_player_dao):
+        """Match ready phase cancels when 5th vote is cast (half + 1)."""
+        record = _make_record(
+            team_1=["p1", "p2", "p3", "p4"],
+            team_2=["p5", "p6", "p7", "p8"],
+            cancel_votes=["p1", "p2", "p3", "p4"],  # 4 votes already
+        )
+        cleared_record = _make_record()
+        mock_queue_dao.get_queue.side_effect = [record, cleared_record]
+        mock_queue_dao.put_queue.return_value = True
+
+        inter = _make_inter(user_id="p5")  # 5th vote
+        cancel_match(inter, "main")
+
+        assert mock_queue_dao.put_queue.call_count == 2
+
+    def test_match_ready_does_not_cancel_at_4_votes(self, mock_queue_dao, mock_player_dao):
+        """Match ready phase does NOT cancel at 4 votes."""
+        record = _make_record(
+            team_1=["p1", "p2", "p3", "p4"],
+            team_2=["p5", "p6", "p7", "p8"],
+            cancel_votes=["p1", "p2", "p3"],  # 3 votes already
+        )
+        mock_queue_dao.get_queue.return_value = record
+        mock_queue_dao.put_queue.return_value = True
+
+        inter = _make_inter(user_id="p4")  # 4th vote — not enough
+        cancel_match(inter, "main")
+
+        assert mock_queue_dao.put_queue.call_count == 1
+
+    def test_duplicate_vote_ignored(self, mock_queue_dao, mock_player_dao):
+        """A player who already voted cannot vote again."""
+        record = _make_record(
+            team_1=["p1", "p2", "p3", "p4"],
+            team_2=["p5", "p6", "p7", "p8"],
+            cancel_votes=["p1"],
+        )
+        mock_queue_dao.get_queue.return_value = record
+        mock_queue_dao.put_queue.return_value = True
+
+        inter = _make_inter(user_id="p1")
+        cancel_match(inter, "main")
+
+        assert record.cancel_votes.count("p1") == 1

--- a/tests/test_match_found_dms.py
+++ b/tests/test_match_found_dms.py
@@ -1,0 +1,184 @@
+"""Tests for match-found DM feature."""
+
+import pytest
+from unittest.mock import MagicMock, patch, call
+from dao.QueueDao import QueueRecord
+from core.QueueManager import send_match_found_dms
+
+
+def _make_record(queue, maps=None, team_1=None, team_2=None):
+    return QueueRecord(
+        guild_id="guild_123",
+        queue_id="main",
+        team_1=team_1 or [],
+        team_2=team_2 or [],
+        queue=queue,
+        cancel_votes=[],
+        team1_votes=[],
+        team2_votes=[],
+        maps=maps or ["Map1", "Map2", "Map3"],
+        map_set=["Map1", "Map2", "Map3"],
+        version=1,
+        expiry=9999999999,
+        result_channel_id="result_ch",
+        team_1_channel_id="team1_ch",
+        team_2_channel_id="team2_ch",
+        money_queue=False,
+        pre_queue=[],
+    )
+
+
+class TestSendMatchFoundDms:
+
+    def test_dms_all_players_in_queue(self):
+        """DM is sent to every player_id in record.queue."""
+        inter = MagicMock()
+        record = _make_record(queue=["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"])
+
+        send_match_found_dms(inter, record)
+
+        assert inter.send_dm.call_count == 8
+        called_ids = [c.kwargs["user_id"] for c in inter.send_dm.call_args_list]
+        assert called_ids == ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"]
+
+    def test_embed_contains_maps(self):
+        """The DM embed includes the selected maps."""
+        inter = MagicMock()
+        record = _make_record(queue=["p1"], maps=["Skidrow", "Terminal", "Highrise"])
+
+        send_match_found_dms(inter, record)
+
+        embed = inter.send_dm.call_args.kwargs["embeds"][0]
+        assert "Skidrow" in embed.fields[0]["value"]
+        assert "Terminal" in embed.fields[0]["value"]
+        assert "Highrise" in embed.fields[0]["value"]
+
+    def test_no_double_send_for_captains_manual_pick(self):
+        """Captains in team_1/team_2 are not DM'd twice (queue is the source of truth)."""
+        inter = MagicMock()
+        # Manual pick: captains appear in teams but queue still holds all 8
+        all_players = ["cap1", "cap2", "p3", "p4", "p5", "p6", "p7", "p8"]
+        record = _make_record(
+            queue=all_players,
+            team_1=["cap1"],
+            team_2=["cap2"],
+        )
+
+        send_match_found_dms(inter, record)
+
+        assert inter.send_dm.call_count == 8
+
+    def test_empty_queue_sends_no_dms(self):
+        """No DMs sent when queue is empty."""
+        inter = MagicMock()
+        record = _make_record(queue=[])
+
+        send_match_found_dms(inter, record)
+
+        inter.send_dm.assert_not_called()
+
+    def test_maps_fallback_when_empty(self):
+        """Embed shows 'TBD' when maps list is empty."""
+        inter = MagicMock()
+        record = _make_record(queue=["p1"], maps=[])
+
+        send_match_found_dms(inter, record)
+
+        embed = inter.send_dm.call_args.kwargs["embeds"][0]
+        assert embed.fields[0]["value"] == "TBD"
+
+
+class TestSendDm:
+
+    def test_send_dm_creates_channel_then_sends_message(self):
+        """send_dm first opens a DM channel, then sends to that channel."""
+        import os
+        import requests
+        from discord_lambda.Interaction import Interaction
+
+        interaction_data = {
+            "type": 2,
+            "token": "tok",
+            "id": "iid",
+            "member": {"user": {"id": "u1", "global_name": "Alice", "username": "alice"}},
+            "data": {"custom_id": None, "name": "cmd", "options": []},
+            "guild": {"id": "g1"},
+        }
+
+        with patch.dict(os.environ, {"BOT_TOKEN": "testtoken"}), \
+             patch("discord_lambda.Interaction.requests.post") as mock_post, \
+             patch("discord_lambda.Interaction.requests.patch"):
+
+            dm_channel_response = MagicMock()
+            dm_channel_response.json.return_value = {"id": "dm_ch_999"}
+            dm_channel_response.raise_for_status = MagicMock()
+
+            send_message_response = MagicMock()
+            send_message_response.json.return_value = {"id": "msg1", "channel_id": "dm_ch_999"}
+            send_message_response.raise_for_status = MagicMock()
+
+            mock_post.side_effect = [dm_channel_response, send_message_response]
+
+            inter = Interaction(interaction_data, app_id="app1")
+            inter.send_dm(user_id="u999", content="Hello!")
+
+            # First call: create DM channel
+            first_call = mock_post.call_args_list[0]
+            assert "users/@me/channels" in first_call.args[0]
+            assert first_call.kwargs["json"] == {"recipient_id": "u999"}
+
+            # Second call: send message to DM channel
+            second_call = mock_post.call_args_list[1]
+            assert "dm_ch_999" in second_call.args[0]
+
+    def test_send_dm_swallows_error(self):
+        """A failed DM does not raise — the error is only printed."""
+        import os
+        from discord_lambda.Interaction import Interaction
+
+        interaction_data = {
+            "type": 2,
+            "token": "tok",
+            "id": "iid",
+            "member": {"user": {"id": "u1", "global_name": "Alice", "username": "alice"}},
+            "data": {"custom_id": None, "name": "cmd", "options": []},
+            "guild": {"id": "g1"},
+        }
+
+        with patch.dict(os.environ, {"BOT_TOKEN": "testtoken"}), \
+             patch("discord_lambda.Interaction.requests.post") as mock_post, \
+             patch("discord_lambda.Interaction.requests.patch"):
+
+            mock_post.side_effect = Exception("network failure")
+
+            inter = Interaction(interaction_data, app_id="app1")
+            # Should not raise
+            inter.send_dm(user_id="u999", content="Hello!")
+
+
+class TestStartQueueButtonSendsDms:
+
+    def test_start_queue_button_calls_send_match_found_dms(self, mock_interaction):
+        """start_queue_button calls send_match_found_dms after updating the queue view."""
+        mock_interaction.custom_id = "start_queue_custom_id#main"
+
+        embed = MagicMock()
+        component = MagicMock()
+
+        record = _make_record(
+            queue=["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"],
+            maps=["Map1", "Map2", "Map3"],
+        )
+
+        with patch("core.ButtonManager.QueueManager.start_match") as mock_start, \
+             patch("core.ButtonManager.queue_dao") as mock_dao, \
+             patch("core.ButtonManager.QueueManager.update_queue_view") as mock_update, \
+             patch("core.ButtonManager.QueueManager.send_match_found_dms") as mock_dms:
+
+            mock_start.return_value = (embed, component)
+            mock_dao.get_queue.return_value = record
+
+            from core.ButtonManager import start_queue_button
+            start_queue_button(guild_id="guild_123", inter=mock_interaction, autopick=False)
+
+            mock_dms.assert_called_once_with(mock_interaction, record)

--- a/tests/test_match_found_dms.py
+++ b/tests/test_match_found_dms.py
@@ -16,7 +16,7 @@ def _make_record(queue, maps=None, team_1=None, team_2=None):
         cancel_votes=[],
         team1_votes=[],
         team2_votes=[],
-        maps=maps or ["Map1", "Map2", "Map3"],
+        maps=maps if maps is not None else ["Map1", "Map2", "Map3"],
         map_set=["Map1", "Map2", "Map3"],
         version=1,
         expiry=9999999999,
@@ -85,7 +85,9 @@ class TestSendMatchFoundDms:
         send_match_found_dms(inter, record)
 
         embed = inter.send_dm.call_args.kwargs["embeds"][0]
-        assert embed.fields[0]["value"] == "TBD"
+        # Embedding objects store fields as a list of dicts
+        maps_field = [f for f in embed.fields if f["name"] == "Maps"][0]
+        assert maps_field["value"] == "TBD"
 
 
 class TestSendDm:
@@ -93,7 +95,6 @@ class TestSendDm:
     def test_send_dm_creates_channel_then_sends_message(self):
         """send_dm first opens a DM channel, then sends to that channel."""
         import os
-        import requests
         from discord_lambda.Interaction import Interaction
 
         interaction_data = {
@@ -106,8 +107,7 @@ class TestSendDm:
         }
 
         with patch.dict(os.environ, {"BOT_TOKEN": "testtoken"}), \
-             patch("discord_lambda.Interaction.requests.post") as mock_post, \
-             patch("discord_lambda.Interaction.requests.patch"):
+             patch("requests.post") as mock_post:
 
             dm_channel_response = MagicMock()
             dm_channel_response.json.return_value = {"id": "dm_ch_999"}
@@ -146,8 +146,7 @@ class TestSendDm:
         }
 
         with patch.dict(os.environ, {"BOT_TOKEN": "testtoken"}), \
-             patch("discord_lambda.Interaction.requests.post") as mock_post, \
-             patch("discord_lambda.Interaction.requests.patch"):
+             patch("requests.post") as mock_post:
 
             mock_post.side_effect = Exception("network failure")
 


### PR DESCRIPTION
## Summary
- **Match found DMs**: When a match starts (pick phase begins), every player in the queue receives a private DM with a "⚔️ Match Found!" embed showing the selected maps
- **Cancel match permissions**: Only players in the queue can cancel during pick phase; only players on teams can cancel during match ready phase
- **Cancel thresholds**: Pick phase requires half the queue size (e.g. 4/8); match ready requires 5 votes (half + 1 for 4v4)
- **Tests**: Full test coverage for all new behaviour; added trueskill/more_itertools mocks to conftest so QueueManager tests run without those packages installed

## Test plan
- [ ] Deploy to dev and fill a queue to 8 players
- [ ] Click "Start queue" — verify all 8 players receive a DM with maps listed
- [ ] During pick phase, have a non-queue player click Cancel — verify nothing happens
- [ ] Have 4 queue players vote cancel during pick phase — verify match is cancelled
- [ ] Let teams fully form, then have a non-team member click Cancel — verify nothing happens
- [ ] Have 4 team members vote cancel — verify match is NOT cancelled
- [ ] Have a 5th team member vote cancel — verify match is cancelled
- [ ] Run `pytest tests/` and verify all tests pass

https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw

---
_Generated by [Claude Code](https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw)_