### PR TITLE
SR decay: leaderboard shows effective SR, committed on match completion

### DIFF
--- a/core/LeaderboardManager.py
+++ b/core/LeaderboardManager.py
@@ -17,7 +17,7 @@ LEADERBOARD_COLOR = 0x7c3aed  # Purple
 
 def build_leaderboard_entries(guild_id: str):
     player_list = player_dao.get_players_by_guild_id(guild_id)
-    sorted_player_list = sorted(player_list, key=lambda x: x.sr, reverse=True)
+    sorted_player_list = sorted(player_list, key=lambda x: x.get_effective_sr(), reverse=True)
 
     entries = []
     rank = 1
@@ -31,7 +31,7 @@ def build_leaderboard_entries(guild_id: str):
         medal = MEDAL_EMOJIS.get(rank, f"`#{rank}`")
         rank_emoji = user.get_rank_emoji()
         streak_emoji = user.get_streak()
-        sr = int(float(user.sr))
+        sr = int(user.get_effective_sr())
         delta = user.delta if (user.delta.startswith("+") or user.delta.startswith("-")) else f"+{user.delta}"
         wins = int(user.mw)
         losses = int(user.ml)

--- a/dao/PlayerDao.py
+++ b/dao/PlayerDao.py
@@ -80,7 +80,7 @@ class PlayerRecord:
       print(f"ELO: {self.elo}, Sigma: {self.sigma}, Rating: {rating}")
       return rating
 
-  def get_effective_sr(self, grace_days: int = 7, decay_rate: int = 2) -> float:
+  def get_effective_sr(self, grace_days: int = 7, decay_rate: int = 10) -> float:
       if self.last_played == 0:
           return float(self.sr)
       days_inactive = (int(time.time()) - self.last_played) / 86400

--- a/dao/PlayerDao.py
+++ b/dao/PlayerDao.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from decimal import Decimal
 
 import boto3
@@ -41,7 +42,7 @@ RANK_SR_RANGES = {
 
 
 class PlayerRecord:
-  def __init__(self, guild_id: str, player_id: str, player_name: str, mw: int = 0, ml: int = 0, sr: float = 0.0, rank: int = 0, elo: float = 25.0, sigma: float = 8.33, delta: str = "+0.0", streak: int = 0, version: int = 0):
+  def __init__(self, guild_id: str, player_id: str, player_name: str, mw: int = 0, ml: int = 0, sr: float = 0.0, rank: int = 0, elo: float = 25.0, sigma: float = 8.33, delta: str = "+0.0", streak: int = 0, version: int = 0, last_played: int = 0):
     self.guild_id = guild_id
     self.player_id = player_id
     self.player_name = player_name
@@ -54,6 +55,7 @@ class PlayerRecord:
     self.delta = delta
     self.streak = int(streak)
     self.version = version
+    self.last_played = int(last_played)
 
 
   def get_streak(self):
@@ -77,6 +79,13 @@ class PlayerRecord:
       rating = float(self.elo - (2 * self.sigma))
       print(f"ELO: {self.elo}, Sigma: {self.sigma}, Rating: {rating}")
       return rating
+
+  def get_effective_sr(self, grace_days: int = 7, decay_rate: int = 2) -> float:
+      if self.last_played == 0:
+          return float(self.sr)
+      days_inactive = (int(time.time()) - self.last_played) / 86400
+      decay = max(0.0, (days_inactive - grace_days) * decay_rate)
+      return max(0.0, float(self.sr) - decay)
 
   def calculate_proj_rank(self):
     hidden_mmr = (self.get_rating()) * 100
@@ -112,31 +121,6 @@ class PlayerRecord:
       else: 
         return "<:OneAboveAll:1367281598143266949>"
 
-  def get_relative_skill(self):
-      print("\n--- Get Relative Skill Debug ---")
-      min_sr, max_sr = RANK_SR_RANGES[self.rank]
-      print(f"SR Range for rank {self.rank}: {min_sr} to {max_sr}")
-      print(f"Current SR: {self.sr}")
-
-      rel_skill = (float(self.sr) - min_sr) / (max_sr - min_sr)
-      print(f"Relative skill calculation: ({self.sr} - {min_sr}) / ({max_sr} - {min_sr}) = {rel_skill}")
-      return max(0.0, min(rel_skill, 1.5))
-
-  def get_tier_gap_modifier(self):
-      print("\n--- Tier Gap Modifier Debug ---")
-      tier_gap = self.calculate_proj_rank() - self.rank
-      base = 1.0
-
-      if tier_gap > 0:
-          # If projected rank is higher, gain more and lose less
-          base += 0.2 * float(tier_gap)
-      elif tier_gap < 0:
-          # If projected rank is lower, gain less and lose more
-          base -= 0.2 * abs(tier_gap)
-
-      print(f"Tier gap: {tier_gap}, Modifier: {max(0.25, base)}")
-      return max(0.25, base)
-
   def calculate_rp_gain(self, base=20, expected=0.5):
       # expected = probability your team wins (ELO formula)
       # underdog win (expected=0.2) → +16; even (0.5) → +10; favourite (0.8) → +4
@@ -152,7 +136,11 @@ class PlayerRecord:
 
   def apply_rp_change(self, loss, expected=0.5):
       print(f"\n=== Apply RP Change: {'WIN' if loss == 0 else 'LOSS'} expected={expected:.2f} ===")
-      curr_rank = self.rank
+
+      # Commit accumulated decay before applying win/loss
+      effective_sr = self.get_effective_sr()
+      self.sr = effective_sr
+
       curr_sr = self.sr
 
       if loss == 0:
@@ -173,6 +161,8 @@ class PlayerRecord:
         self.rank = min(3, placement_rank)
         self.sr = RANK_SR_RANGES[self.rank][0] + 50
         self.delta = str(int(float(self.sr - curr_sr)))
+
+      self.last_played = int(time.time())
 
 class PlayerDao:
   def __init__(self):
@@ -247,4 +237,7 @@ class PlayerDao:
       rank = 0
       if response.get("rank") is not None:
         rank = int(response['rank'])
-      return PlayerRecord(player_id=response["player_id"], player_name=response['player_name'], guild_id=response["guild_id"], mw=response["mw"], ml=response["ml"], sr=sr, rank=rank, elo=response["elo"], sigma=response["sigma"], delta=response["delta"], streak=response["streak"], version=response["version"])
+      last_played = 0
+      if response.get("last_played") is not None:
+        last_played = int(response["last_played"])
+      return PlayerRecord(player_id=response["player_id"], player_name=response['player_name'], guild_id=response["guild_id"], mw=response["mw"], ml=response["ml"], sr=sr, rank=rank, elo=response["elo"], sigma=response["sigma"], delta=response["delta"], streak=response["streak"], version=response["version"], last_played=last_played)

--- a/tests/test_sr_calculation.py
+++ b/tests/test_sr_calculation.py
@@ -1,0 +1,144 @@
+"""Tests for SR gain/loss/rank and decay calculations."""
+
+import time
+import pytest
+from dao.PlayerDao import PlayerRecord, RANK_SR_RANGES
+
+
+def _player(sr=200, rank=2, mw=10, ml=5, elo=25.0, sigma=8.33, last_played=0):
+    return PlayerRecord(
+        guild_id="guild_123",
+        player_id="p1",
+        player_name="TestPlayer",
+        mw=mw,
+        ml=ml,
+        sr=sr,
+        rank=rank,
+        elo=elo,
+        sigma=sigma,
+        last_played=last_played,
+    )
+
+
+class TestRpGain:
+    def test_even_match_gain(self):
+        p = _player()
+        assert p.calculate_rp_gain(expected=0.5) == 10
+
+    def test_underdog_win_gain(self):
+        p = _player()
+        assert p.calculate_rp_gain(expected=0.2) == 16
+
+    def test_favourite_win_gain(self):
+        p = _player()
+        assert p.calculate_rp_gain(expected=0.8) == 4
+
+    def test_minimum_gain_is_1(self):
+        p = _player()
+        assert p.calculate_rp_gain(expected=0.99) >= 1
+
+
+class TestRpLoss:
+    def test_even_match_loss(self):
+        p = _player()
+        assert p.calculate_rp_loss(expected=0.5) == -10
+
+    def test_favourite_loss(self):
+        p = _player()
+        assert p.calculate_rp_loss(expected=0.8) == -16
+
+    def test_underdog_loss(self):
+        p = _player()
+        assert p.calculate_rp_loss(expected=0.2) == -4
+
+    def test_maximum_loss_is_neg_1(self):
+        p = _player()
+        assert p.calculate_rp_loss(expected=0.01) <= -1
+
+
+class TestApplyRpChange:
+    def test_win_increases_sr(self):
+        p = _player(sr=200, rank=2)
+        p.apply_rp_change(loss=0, expected=0.5)
+        assert p.sr > 200
+
+    def test_loss_decreases_sr(self):
+        p = _player(sr=200, rank=2)
+        p.apply_rp_change(loss=1, expected=0.5)
+        assert p.sr < 200
+
+    def test_sr_floor_is_zero(self):
+        p = _player(sr=3, rank=0)
+        p.apply_rp_change(loss=1, expected=0.5)
+        assert p.sr >= 0
+
+    def test_win_triggers_rank_up(self):
+        # SR=99, rank=0 (Bronze ceiling). A win should push into Silver (rank 1).
+        p = _player(sr=99, rank=0)
+        p.apply_rp_change(loss=0, expected=0.5)
+        assert p.rank >= 1
+
+    def test_loss_triggers_rank_down(self):
+        # SR=100, rank=1 (Silver floor). A loss pushes back to Bronze (rank 0).
+        p = _player(sr=100, rank=1)
+        p.apply_rp_change(loss=1, expected=0.5)
+        assert p.rank == 0
+
+    def test_delta_positive_on_win(self):
+        p = _player(sr=200, rank=2)
+        p.apply_rp_change(loss=0, expected=0.5)
+        assert p.delta.startswith("+")
+
+    def test_delta_negative_on_loss(self):
+        p = _player(sr=200, rank=2)
+        p.apply_rp_change(loss=1, expected=0.5)
+        assert p.delta.startswith("-")
+
+    def test_last_played_updated(self):
+        before = int(time.time()) - 1
+        p = _player()
+        p.apply_rp_change(loss=0, expected=0.5)
+        assert p.last_played >= before
+
+    def test_placement_fires_on_10th_game(self):
+        # Player just hit 10th game (mw+ml will equal 10 after apply_rp_change increments ml)
+        # mw=9, ml=0 → after win mw=10, total=10 → placement fires
+        p = _player(sr=50, rank=0, mw=9, ml=0)
+        p.mw = 10  # simulate post-increment state that apply_rp_change sees
+        p.ml = 0
+        p.apply_rp_change(loss=0, expected=0.5)
+        # Placement: rank capped at 3, sr = RANK_SR_RANGES[rank][0] + 50
+        assert p.sr == RANK_SR_RANGES[p.rank][0] + 50
+        assert p.rank <= 3
+
+
+class TestGetEffectiveSr:
+    def test_no_decay_within_grace_period(self):
+        recent = int(time.time()) - (3 * 86400)  # 3 days ago, within 7-day grace
+        p = _player(sr=300, last_played=recent)
+        assert p.get_effective_sr() == 300.0
+
+    def test_decay_after_grace_period(self):
+        # 14 days ago → 7 days of decay at rate 2 = -14
+        last = int(time.time()) - (14 * 86400)
+        p = _player(sr=300, last_played=last)
+        effective = p.get_effective_sr()
+        assert effective < 300.0
+        assert abs(effective - 286.0) < 1.0  # allow 1 SR rounding tolerance
+
+    def test_effective_sr_floor_is_zero(self):
+        last = int(time.time()) - (365 * 86400)  # 1 year inactive
+        p = _player(sr=10, last_played=last)
+        assert p.get_effective_sr() == 0.0
+
+    def test_no_decay_when_last_played_is_zero(self):
+        p = _player(sr=200, last_played=0)
+        assert p.get_effective_sr() == 200.0
+
+    def test_decay_commits_to_sr_on_match(self):
+        # 14 days inactive → 14 SR of decay. SR before match: 300 → effective 286.
+        # Win at even odds → +10. Final SR should be ~296.
+        last = int(time.time()) - (14 * 86400)
+        p = _player(sr=300, rank=2, last_played=last)
+        p.apply_rp_change(loss=0, expected=0.5)
+        assert abs(p.sr - 296.0) < 2.0

--- a/tests/test_sr_calculation.py
+++ b/tests/test_sr_calculation.py
@@ -119,12 +119,12 @@ class TestGetEffectiveSr:
         assert p.get_effective_sr() == 300.0
 
     def test_decay_after_grace_period(self):
-        # 14 days ago → 7 days of decay at rate 2 = -14
+        # 14 days ago → 7 days of decay at rate 10 = -70
         last = int(time.time()) - (14 * 86400)
         p = _player(sr=300, last_played=last)
         effective = p.get_effective_sr()
         assert effective < 300.0
-        assert abs(effective - 286.0) < 1.0  # allow 1 SR rounding tolerance
+        assert abs(effective - 230.0) < 1.0  # allow 1 SR rounding tolerance
 
     def test_effective_sr_floor_is_zero(self):
         last = int(time.time()) - (365 * 86400)  # 1 year inactive
@@ -136,9 +136,9 @@ class TestGetEffectiveSr:
         assert p.get_effective_sr() == 200.0
 
     def test_decay_commits_to_sr_on_match(self):
-        # 14 days inactive → 14 SR of decay. SR before match: 300 → effective 286.
-        # Win at even odds → +10. Final SR should be ~296.
+        # 14 days inactive → 7 days of decay at rate 10 = -70. SR before match: 300 → effective 230.
+        # Win at even odds → +10. Final SR should be ~240.
         last = int(time.time()) - (14 * 86400)
         p = _player(sr=300, rank=2, last_played=last)
         p.apply_rp_change(loss=0, expected=0.5)
-        assert abs(p.sr - 296.0) < 2.0
+        assert abs(p.sr - 240.0) < 2.0


### PR DESCRIPTION
## Summary

- **SR decay**: Players inactive for more than 7 days lose 10 SR/day (a full rank every ~10 days). Decay is reflected immediately on the leaderboard via `get_effective_sr()` and committed to the database on next match completion alongside the win/loss delta. The `last_played` timestamp is reset on every match.
- **Legacy players**: Players with no `last_played` in DynamoDB default to 0, which skips decay entirely — no penalty for existing accounts.
- **Dead code removal**: Deleted `get_relative_skill()` and `get_tier_gap_modifier()` which were unused since the SR rework.
- **22 new tests** in `tests/test_sr_calculation.py` covering gain/loss clamping, rank transitions, placement, decay grace period, decay floor, and decay-commit-on-match.

## Test plan

- [ ] All tests pass (`pytest tests/ -v`)
- [ ] Deploy to dev and verify leaderboard shows decayed SR for inactive players after 7+ days
- [ ] Play a match as an inactive player — confirm decay is committed and `last_played` resets
- [ ] Confirm new/legacy players (no `last_played`) see no decay on leaderboard

https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw