### PR TITLE
Default last_played to current time for legacy players

### DIFF
--- a/dao/PlayerDao.py
+++ b/dao/PlayerDao.py
@@ -237,7 +237,7 @@ class PlayerDao:
       rank = 0
       if response.get("rank") is not None:
         rank = int(response['rank'])
-      last_played = 0
+      last_played = int(time.time())
       if response.get("last_played") is not None:
         last_played = int(response["last_played"])
       return PlayerRecord(player_id=response["player_id"], player_name=response['player_name'], guild_id=response["guild_id"], mw=response["mw"], ml=response["ml"], sr=sr, rank=rank, elo=response["elo"], sigma=response["sigma"], delta=response["delta"], streak=response["streak"], version=response["version"], last_played=last_played)


### PR DESCRIPTION
## Summary

- Legacy DynamoDB records that don't have a `last_played` field now default to the current timestamp instead of 0. This means existing players start a fresh 7-day grace period from the moment they are first read after this deploys, rather than being permanently exempt from SR decay.

## Test plan

- [ ] All tests pass (`pytest tests/ -v`)
- [ ] Deploy to dev and confirm legacy players (no `last_played` in DynamoDB) show full SR on the leaderboard immediately after deploy
- [ ] After 7+ days, confirm their SR starts decaying at 10/day

https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw

---
_Generated by [Claude Code](https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw)_