### PR TITLE
Fix ELO divisor so SR gains/losses reflect actual team MMR difference

### DIFF
--- a/trueskillapi/__init__.py
+++ b/trueskillapi/__init__.py
@@ -73,7 +73,7 @@ class TrueSkillAccessor:
             lost = lost + 1
 
         your_avg_rating = sum(u.get_rating() for u in team_ratings) / len(team_ratings) if team_ratings else 0
-        expected = 1 / (1 + 10 ** ((enemy_avg_rating - your_avg_rating) / 400))
+        expected = 1 / (1 + 10 ** ((enemy_avg_rating - your_avg_rating) / 4))
         print(f"[SR] your_avg={your_avg_rating:.1f} enemy_avg={enemy_avg_rating:.1f} expected={expected:.2f}")
 
         for user in team_ratings:


### PR DESCRIPTION
## Summary

`get_rating()` returns `elo - 2*sigma` which sits in the ~0–21 range. `RANK_ELO_RANGES` is built on `hidden_mmr = get_rating() * 100` (range ~0–2100), the same scale as traditional chess ELO where 400 is the correct divisor.

Using 400 as the divisor against raw `get_rating()` values meant the exponent was always tiny, compressing every expected outcome to ~0.5 — so all wins gave ~+10 SR and all losses ~-10 SR regardless of how mismatched the teams were.

**Fix:** divisor `400 → 4` (= 400 ÷ 100), which correctly maps a one-rank difference to a meaningful win probability shift.

**Before:** even a top-rank player vs a Bronze → expected ≈ 0.5 → everyone gets ±10  
**After:** a 10-point `get_rating()` gap (≈ 4 rank tiers) → expected ≈ 0.09/0.91 → underdog wins yield ~+18, favourite wins yield ~+2

## Test plan

- [ ] All tests pass (`pytest tests/ -v`)
- [ ] Deploy to dev and run a mismatched game — verify the lower-ranked team gains more SR on a win than the higher-ranked team would

https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw

---
_Generated by [Claude Code](https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw)_