### PR TITLE
Fix four ELO algorithm bugs: pre-match rating, game avg, decay delta, is_ranked threshold

### DIFF
--- a/dao/PlayerDao.py
+++ b/dao/PlayerDao.py
@@ -147,12 +147,13 @@ class PlayerRecord:
       print(f"\n=== Apply RP Change: {'WIN' if loss == 0 else 'LOSS'} expected={expected:.2f} ===")
 
       # Commit accumulated decay before applying win/loss
+      original_sr = float(self.sr)
       effective_sr = self.get_effective_sr()
       self.sr = effective_sr
 
       curr_sr = self.sr
 
-      is_ranked = (self.mw + self.ml) > 10
+      is_ranked = (self.mw + self.ml) >= 10
 
       if loss == 0:
         sr_gain = self.calculate_rp_gain(expected=expected)
@@ -163,7 +164,8 @@ class PlayerRecord:
       elif is_ranked and not self._used_forgiveness_today():
         print(f"[Daily forgiveness] absorbing first loss of the day for {self.player_name}")
         self.last_loss_forgiven = int(time.time())
-        self.delta = "+0"
+        decay_change = int(effective_sr - original_sr)
+        self.delta = str(decay_change) if decay_change < 0 else "+0"
       else:
         sr_loss = self.calculate_rp_loss(expected=expected)
         new_sr = max(0, curr_sr + sr_loss)

--- a/tests/test_sr_calculation.py
+++ b/tests/test_sr_calculation.py
@@ -168,7 +168,7 @@ class TestDailyForgiveness:
         assert p.sr < 200.0
 
     def test_unranked_player_not_forgiven(self):
-        """Players in placement (<=10 games) don't get forgiveness."""
+        """Players in placement (<10 games) don't get forgiveness."""
         p = _player(sr=50, rank=0, mw=5, ml=4)  # 9 games total, in placement
         p.apply_rp_change(loss=1, expected=0.5)
         assert p.sr < 50.0
@@ -186,3 +186,25 @@ class TestDailyForgiveness:
         p = _player(sr=200, rank=2, mw=11, ml=5)
         p.apply_rp_change(loss=0, expected=0.5)
         assert p.sr > 200.0
+
+    def test_forgiven_loss_delta_reflects_decay(self):
+        """When forgiveness fires and decay was applied, delta shows the decay amount."""
+        last = int(time.time()) - (14 * 86400)  # 14 days inactive → 70 SR decay
+        p = _player(sr=300, rank=2, mw=11, ml=5, last_played=last)
+        p.apply_rp_change(loss=1, expected=0.5)
+        assert p.delta == "-70"
+
+    def test_forgiven_loss_delta_plus_zero_when_no_decay(self):
+        """When forgiveness fires with no decay, delta shows +0."""
+        p = _player(sr=200, rank=2, mw=11, ml=5, last_played=0)
+        p.apply_rp_change(loss=1, expected=0.5)
+        assert p.delta == "+0"
+
+    def test_game_10_loss_eligible_for_forgiveness(self):
+        """A player on their 10th game can use daily forgiveness on a loss."""
+        p = _player(sr=200, rank=2, mw=9, ml=0)  # after mw increment → mw+ml=10
+        p.mw = 10
+        p.ml = 0
+        p.apply_rp_change(loss=1, expected=0.5)
+        # Forgiveness fires → SR not reduced by loss (placement then overrides SR anyway)
+        assert p.last_loss_forgiven > 0

--- a/trueskillapi/__init__.py
+++ b/trueskillapi/__init__.py
@@ -35,9 +35,11 @@ class TrueSkillAccessor:
 
         win_avg_rating = sum(u.get_rating() for u in win_team_ratings) / len(win_team_ratings)
         lose_avg_rating = sum(u.get_rating() for u in lose_team_ratings) / len(lose_team_ratings)
+        game_avg_rating = (sum(u.get_rating() for u in win_team_ratings) + sum(u.get_rating() for u in lose_team_ratings)) / (len(win_team_ratings) + len(lose_team_ratings))
+        print(f"[SR] win_avg={win_avg_rating:.1f} lose_avg={lose_avg_rating:.1f} game_avg={game_avg_rating:.1f}")
 
-        self.update_ratings(new_ratings, win_team_ratings, 0, enemy_avg_rating=lose_avg_rating)
-        self.update_ratings(new_ratings, lose_team_ratings, 1, enemy_avg_rating=win_avg_rating)
+        self.update_ratings(new_ratings, win_team_ratings, 0, game_avg_rating=game_avg_rating)
+        self.update_ratings(new_ratings, lose_team_ratings, 1, game_avg_rating=game_avg_rating)
 
 
     def get_player_data(self, team: list, guild_id: str) -> list[PlayerRecord]:
@@ -62,7 +64,7 @@ class TrueSkillAccessor:
         else:
             return 0.8
 
-    def update_ratings(self, new_ratings, team_ratings: list[PlayerRecord], tuple_idx: int, enemy_avg_rating: float = 0):
+    def update_ratings(self, new_ratings, team_ratings: list[PlayerRecord], tuple_idx: int, game_avg_rating: float = 0):
         idx = 0
         lost = 0
         won = 0
@@ -71,9 +73,6 @@ class TrueSkillAccessor:
             won = won + 1
         else:
             lost = lost + 1
-
-        your_avg_rating = sum(u.get_rating() for u in team_ratings) / len(team_ratings) if team_ratings else 0
-        print(f"[SR] your_avg={your_avg_rating:.1f} enemy_avg={enemy_avg_rating:.1f}")
 
         for user in team_ratings:
             print("Updating streak for player_name: " + user.player_name + " , streak: " + str(user.streak))
@@ -92,6 +91,8 @@ class TrueSkillAccessor:
             user.mw = int(user.mw) + won
             user.ml = int(user.ml) + lost
 
+            pre_match_rating = user.get_rating()  # capture before TrueSkill updates elo/sigma
+
             old_elo = float(user.elo)
             new_elo = float(new_ratings[tuple_idx][idx].mu)
             new_sigma = float(new_ratings[tuple_idx][idx].sigma)
@@ -103,9 +104,9 @@ class TrueSkillAccessor:
             user.elo = old_elo + elo_change
             user.sigma = max(0.5, new_sigma)  # Minimum sigma of 0.5 prevents underflow
 
-            # Per-player expected: individual rating vs enemy team average
-            user_expected = 1 / (1 + 10 ** ((enemy_avg_rating - user.get_rating()) / 20))
-            print(f"[SR] {user.player_name} rating={user.get_rating():.1f} enemy_avg={enemy_avg_rating:.1f} expected={user_expected:.2f}")
+            # Per-player expected: pre-match individual rating vs game average (all 8 players)
+            user_expected = 1 / (1 + 10 ** ((game_avg_rating - pre_match_rating) / 20))
+            print(f"[SR] {user.player_name} rating={pre_match_rating:.1f} game_avg={game_avg_rating:.1f} expected={user_expected:.2f}")
             user.apply_rp_change(tuple_idx, expected=user_expected)
 
             print(f"Writing player_data record to {user}")


### PR DESCRIPTION
## Summary

Four correctness bugs found in a deep algorithm review, all fixed in one commit.

**1. Pre-match rating for expected calculation**
`user_expected` was computed from `user.get_rating()` *after* TrueSkill had already updated `elo` and `sigma`. A big win raised the player's rating, making them look like a bigger favourite, suppressing their SR gain. Now `pre_match_rating` is captured before any TrueSkill mutation.

**2. Game average as expected reference (SR fairness)**
Previously each player's expected was computed against the *enemy team average*. A high-rated winner vs a weak enemy avg got expected ≈ 0.97 → only +1 SR, while a low-rated loser vs a strong enemy avg got expected ≈ 0.97 → -18 SR. Wildly asymmetric. Now all 8 players are compared against the *game average*, so a strong player on a winning team gains less than their weaker teammates, and a strong player on the losing team loses more. Individual accountability, consistent reference.

**3. Forgiven loss delta reflects decay**
When daily forgiveness fires, decay had already been silently committed to `self.sr` but delta showed `+0`. Players saw no change while their SR had dropped. Delta now shows the decay amount (e.g. `-70`) so the move is visible.

**4. `is_ranked` threshold `>= 10`**
Was `> 10`, meaning the 10th (placement) game could never trigger daily forgiveness. Changed to `>= 10` so a ranked player's first loss on their placement game is protected.

## Test plan

- [ ] All tests pass (`pytest tests/ -v`)  
- [ ] Deploy to dev, run a mismatched game — verify lower-rated players on winning team gain more than higher-rated teammates
- [ ] Verify a player coming back after 14 days inactive sees `-70` delta on their first forgiven loss, not `+0`
- [ ] Confirm game 10 loss triggers forgiveness if unused that day

https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw

---
_Generated by [Claude Code](https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw)_