### PR TITLE
Team queue UX: interactive pool, instant ranks, leaderboard auto-update

### DIFF
--- a/commands/queue.py
+++ b/commands/queue.py
@@ -4,12 +4,11 @@ from discord_lambda import CommandRegistry, Interaction, CommandArg
 def queue(inter: Interaction, queue_name: str = "1") -> None:
   print(f"Creating queue with: {queue_name} in guild_id: {inter.guild_id}")
 
-  # A queue record flagged is_team_queue renders the premade-team pool board
-  # instead of the solo queue. Teams are managed via the /team_* commands.
   flagged = QueueManager.queue_dao.get_queue_or_none(inter.guild_id, queue_name)
   if flagged is not None and getattr(flagged, "is_team_queue", False):
-    embed = TeamManager.build_pool_board_embed(inter.guild_id)
-    inter.send_response(embeds=[embed], ephemeral=False)
+    embeds, components = TeamManager.build_team_pool_embed(inter.guild_id, queue_name)
+    resp = inter.send_response(embeds=embeds, components=components, ephemeral=False)
+    QueueManager.update_message_id(inter.guild_id, resp[0], resp[1], queue_id=queue_name)
     return
 
   if inter.guild_id != "1123491132765110302" and queue_name != 'HP':

--- a/core/ButtonManager.py
+++ b/core/ButtonManager.py
@@ -9,6 +9,12 @@ def button_flow_tree(interaction: Interaction):
   # checked before the solo leaderboard page button.
   if TeamLeaderboardManager.team_leaderboard_page_custom_id in interaction.custom_id:
     team_leaderboard_page_button(interaction.guild_id, interaction)
+  elif QueueManager.team_queue_join_custom_id in interaction.custom_id:
+    team_pool_join_button(interaction.guild_id, interaction)
+  elif QueueManager.team_queue_leave_custom_id in interaction.custom_id:
+    team_pool_leave_button(interaction.guild_id, interaction)
+  elif QueueManager.team_queue_start_custom_id in interaction.custom_id:
+    team_pool_start_button(interaction.guild_id, interaction)
   elif LeaderboardManager.leaderboard_page_custom_id in interaction.custom_id:
     leaderboard_page_button(interaction.guild_id, interaction)
   elif QueueManager.join_waitlist_custom_id in interaction.custom_id or "join_pre_queue" in interaction.custom_id:
@@ -193,6 +199,43 @@ def cancel_match_button(guild_id: str, inter: Interaction):
 
   record = queue_dao.get_queue(guild_id=guild_id, queue_id=inter.custom_id.split("#")[1])
   QueueManager.update_queue_view(record, embeds=embed, components=component, inter=inter)
+
+
+def team_pool_join_button(guild_id: str, inter: Interaction):
+  print("Team pool Queue Up button clicked")
+  queue_id = inter.custom_id.split("#")[1]
+  resp = QueueManager.team_pool_join(inter, queue_id)
+  if resp is None:
+    return
+  embed, component = resp
+  record = queue_dao.get_queue(guild_id=guild_id, queue_id=queue_id)
+  QueueManager.update_queue_view(record, embeds=embed, components=component, inter=inter)
+
+
+def team_pool_leave_button(guild_id: str, inter: Interaction):
+  print("Team pool Dequeue button clicked")
+  queue_id = inter.custom_id.split("#")[1]
+  resp = QueueManager.team_pool_leave(inter, queue_id)
+  if resp is None:
+    return
+  embed, component = resp
+  record = queue_dao.get_queue(guild_id=guild_id, queue_id=queue_id)
+  QueueManager.update_queue_view(record, embeds=embed, components=component, inter=inter)
+
+
+def team_pool_start_button(guild_id: str, inter: Interaction):
+  print("Team pool Start Match button clicked")
+  queue_id = inter.custom_id.split("#")[1]
+  pool_record = queue_dao.get_queue(guild_id=guild_id, queue_id=queue_id)
+  channel_id = next(iter(pool_record.channel_config), None)
+  if not channel_id:
+    return
+  resp = QueueManager.team_pool_start(inter, queue_id, channel_id)
+  if resp is None:
+    return
+  embed, component = resp
+  pool_record = queue_dao.get_queue(guild_id=guild_id, queue_id=queue_id)
+  QueueManager.update_queue_view(pool_record, embeds=embed, components=component, inter=inter)
 
 
 

--- a/core/QueueManager.py
+++ b/core/QueueManager.py
@@ -686,8 +686,25 @@ def update_message_id(guild_id, msg_id, channel_id, queue_id):
     queue_dao.put_queue(response)
 
 def team_pool_join(inter: Interaction, queue_id: str):
-    """Captain queues their team from the pool board button."""
+    """Captain queues their team from the pool board button.
+    Blocks if any team member is already in an active solo queue."""
     import core.TeamManager as TM
+    # Check up-front that the captain isn't already in any solo queue lobby
+    # (covers the scenario where someone is queued solo AND tries to queue their team).
+    team_check = TM.team_dao.get_team_by_player(inter.guild_id, inter.user_id)
+    if team_check is not None:
+        for player_id in team_check.players:
+            solo = queue_dao.get_queue_or_none(inter.guild_id, "1")
+            if solo is not None and player_id in solo.queue:
+                inter.send_followup(
+                    embeds=[Embedding(
+                        ":x: Player in solo queue",
+                        f"<@{player_id}> is already in the solo queue. They must leave it before your team can queue.",
+                        color=0xFF0000,
+                    )],
+                    ephemeral=True,
+                )
+                return None
     result = TM.queue_team(inter.guild_id, inter.user_id)
     if result.color == TM.ERROR_COLOR:
         inter.send_followup(embeds=[result], ephemeral=True)

--- a/core/QueueManager.py
+++ b/core/QueueManager.py
@@ -22,6 +22,9 @@ player_pick_custom_id = "player_pick"
 cancel_match_custom_id = "cancel_match"
 team_1_won_custom_id = "team_1_won"
 team_2_won_custom_id = "team_2_won"
+team_queue_join_custom_id = "team_queue_join"
+team_queue_leave_custom_id = "team_queue_leave"
+team_queue_start_custom_id = "team_queue_start"
 
 MAX_QUEUE_SIZE = 8
 
@@ -535,6 +538,9 @@ def player_pick(inter: Interaction, queue_id: str):
 
 
 def update_queue_embed(record: QueueRecord) -> ([Embedding], [Components]):
+    if getattr(record, "is_team_queue", False) and len(record.team_1) == 0:
+        import core.TeamManager as TeamManager
+        return TeamManager.build_team_pool_embed(record.guild_id, record.queue_id)
     if len(record.team_1) == 0 or len(record.team_2) == 0:
         queue_str = ""
         for user in record.queue:
@@ -676,6 +682,78 @@ def update_message_id(guild_id, msg_id, channel_id, queue_id):
     response.channel_id = channel_id
     response.channel_config[channel_id] = msg_id
     queue_dao.put_queue(response)
+
+def team_pool_join(inter: Interaction, queue_id: str):
+    """Captain queues their team from the pool board button."""
+    import core.TeamManager as TM
+    result = TM.queue_team(inter.guild_id, inter.user_id)
+    if result.color == TM.ERROR_COLOR:
+        inter.send_followup(embeds=[result], ephemeral=True)
+        return None
+    return TM.build_team_pool_embed(inter.guild_id, queue_id)
+
+
+def team_pool_leave(inter: Interaction, queue_id: str):
+    """Captain dequeues their team from the pool board button."""
+    import core.TeamManager as TM
+    result = TM.dequeue_team(inter.guild_id, inter.user_id)
+    if result.color == TM.ERROR_COLOR:
+        inter.send_followup(embeds=[result], ephemeral=True)
+        return None
+    return TM.build_team_pool_embed(inter.guild_id, queue_id)
+
+
+def team_pool_start(inter: Interaction, queue_id: str, channel_id: str):
+    """Start a match from the pool board. Posts the Match Ready embed to
+    channel_id and returns the refreshed (empty) pool embed."""
+    import core.TeamManager as TM
+    queued = TM.team_dao.get_queued_teams(inter.guild_id)
+    if len(queued) < 2:
+        inter.send_followup(
+            embeds=[Embedding(":x: Not enough teams",
+                              f"Need at least 2 teams searching ({len(queued)} in pool).",
+                              color=0xFF0000)],
+            ephemeral=True,
+        )
+        return None
+    team_a, team_b = TM._pick_fairest_pair(queued)
+    base = queue_dao.get_queue_or_none(inter.guild_id, "1")
+    if base is None:
+        inter.send_followup(
+            embeds=[Embedding(":x: Queue not set up",
+                              "No base queue `1` exists to inherit channels from.",
+                              color=0xFF0000)],
+            ephemeral=True,
+        )
+        return None
+    match_queue_id = TM.TEAM_MATCH_PREFIX + team_a.team_id[:8]
+    maps = random.sample(base.map_set, min(3, len(base.map_set)))
+    match_record = QueueRecord(
+        guild_id=inter.guild_id, money_queue=False, queue_id=match_queue_id,
+        team_1=list(team_a.players), team_2=list(team_b.players), queue=list(),
+        cancel_votes=list(), team1_votes=list(), team2_votes=list(),
+        maps=maps, map_set=base.map_set, version=0, expiry=0,
+        result_channel_id=base.result_channel_id,
+        team_1_channel_id=base.team_1_channel_id, team_2_channel_id=base.team_2_channel_id,
+        message_id=None, channel_id=None, channel_config={},
+        waitlist=list(),
+        is_team_queue=True, team_1_id=team_a.team_id, team_2_id=team_b.team_id,
+    )
+    match_record.update_expiry_date()
+    queue_dao.put_queue(match_record)
+    team_a.status = TM.STATUS_IN_MATCH
+    team_b.status = TM.STATUS_IN_MATCH
+    TM.team_dao.put_team(team_a)
+    TM.team_dao.put_team(team_b)
+    match_embeds, match_components = update_queue_embed(match_record)
+    resp = inter.send_message(channel_id=channel_id, embeds=match_embeds, components=match_components)
+    posted = queue_dao.get_queue(inter.guild_id, match_queue_id)
+    posted.message_id = resp[0]
+    posted.channel_id = resp[1]
+    posted.channel_config = {resp[1]: resp[0]}
+    queue_dao.put_queue(posted)
+    return TM.build_team_pool_embed(inter.guild_id, queue_id)
+
 
 def update_queue_view(record: QueueRecord, embeds: list[Embedding], components: list[Components], inter: Interaction):
     curr_time = int(datetime.utcnow().timestamp())

--- a/core/QueueManager.py
+++ b/core/QueueManager.py
@@ -376,12 +376,14 @@ def _complete_team_match_result(inter: Interaction, response: QueueRecord, win_t
     to edit the live Match Ready message into a completed view (so it doesn't
     stay frozen on the old roster)."""
     import core.TeamManager as TeamManager
+    from core import TeamLeaderboardManager
     ts.post_team_match(win_team_id=win_team_id, lose_team_id=lose_team_id, guild_id=inter.guild_id)
     done_embed = TeamManager.generate_team_match_done_embed(win_team_id, lose_team_id, inter.guild_id)
     inter.send_message(channel_id=response.result_channel_id, embeds=[done_embed])
     TeamManager.complete_team_match(inter.guild_id, win_team_id, lose_team_id)
     response.clear_queue(reset_expiry=False)
     queue_dao.put_queue(response)
+    TeamLeaderboardManager.post_team_leaderboard(inter.guild_id, inter)
     # No buttons on the completed view — the match is over.
     return [done_embed], [Components()]
 

--- a/core/TeamLeaderboardManager.py
+++ b/core/TeamLeaderboardManager.py
@@ -1,8 +1,10 @@
+from dao.LeaderboardDao import LeaderboardDao
 from dao.TeamDao import TeamDao
 from discord_lambda import Components
 from discord_lambda.Interaction import Embedding
 
 team_dao = TeamDao()
+leaderboard_dao = LeaderboardDao()
 
 team_leaderboard_page_custom_id = "team_leaderboard_page"
 PAGE_SIZE = 10
@@ -18,7 +20,7 @@ def build_team_leaderboard_entries(guild_id: str):
     entries = []
     rank = 1
     for team in sorted_teams:
-        if (int(team.tmw) + int(team.tml)) < 10:
+        if (int(team.tmw) + int(team.tml)) < 1:
             continue
 
         medal = MEDAL_EMOJIS.get(rank, f"`#{rank}`")
@@ -53,17 +55,48 @@ def build_team_leaderboard_page(guild_id: str, page: int):
             f"└─ SR: **{entry['sr']}** ({entry['delta']}) | {entry['wins']}W / {entry['losses']}L"
         )
 
-    description = "\n".join(rows) if rows else "No teams with 10+ games yet. Keep playing!"
+    description = "\n".join(rows) if rows else "No team matches completed yet. Keep playing!"
 
     embed = Embedding(
         title="🏆 Team Leaderboard",
         desc=description,
         color=LEADERBOARD_COLOR,
     )
-    embed.set_footer(text=f"Page {page + 1}/{total_pages}  •  10 team games required to place")
+    embed.set_footer(text=f"Page {page + 1}/{total_pages}  •  Ranked after first match")
 
     component = Components()
     component.add_button("◀ Previous", f"{team_leaderboard_page_custom_id}#{page - 1}", page <= 0, 2)
     component.add_button("Next ▶", f"{team_leaderboard_page_custom_id}#{page + 1}", page >= total_pages - 1, 1)
 
     return embed, component
+
+
+def post_team_leaderboard(guild_id: str, inter) -> None:
+    """Called automatically after a team match ends — refreshes the pinned team
+    leaderboard message. Silently skips if no team leaderboard channel is set."""
+    record = leaderboard_dao.get_leaderboard(guild_id)
+    if not record.team_leaderboard_channel_id:
+        print("No team leaderboard channel configured, skipping post")
+        return
+
+    embed, component = build_team_leaderboard_page(guild_id, 0)
+
+    if record.team_leaderboard_message_id:
+        inter.delete_message(
+            message_id=record.team_leaderboard_message_id,
+            channel_id=record.team_leaderboard_channel_id,
+        )
+
+    resp = inter.send_message(
+        channel_id=record.team_leaderboard_channel_id,
+        embeds=[embed],
+        components=[component],
+    )
+
+    record.team_leaderboard_message_id = resp[0]
+    leaderboard_resp = leaderboard_dao.put_leaderboard(record)
+    if leaderboard_resp is None:
+        inter.delete_message(
+            message_id=record.team_leaderboard_message_id,
+            channel_id=record.team_leaderboard_channel_id,
+        )

--- a/core/TeamManager.py
+++ b/core/TeamManager.py
@@ -6,7 +6,7 @@ import random
 from core import QueueManager
 from dao.QueueDao import QueueDao, QueueRecord
 from dao.TeamDao import TeamDao, TeamRecord, MAX_TEAM_SIZE, STATUS_IDLE, STATUS_QUEUED, STATUS_IN_MATCH
-from discord_lambda import Embedding
+from discord_lambda import Embedding, Components
 from discord_lambda import Interaction
 from trueskillapi import TrueSkillAccessor
 
@@ -64,25 +64,27 @@ def build_team_lobby_embed(team: TeamRecord) -> Embedding:
     return embed
 
 
-def build_pool_board_embed(guild_id: str) -> Embedding:
-    """Rendered when /queue <name> is called on a record flagged is_team_queue.
-    Shows every team currently searching for a match."""
+def build_team_pool_embed(guild_id: str, queue_id: str):
+    """Interactive team queue pool embed. Captains click Queue Up/Dequeue;
+    anyone can click Start Match once ≥2 teams are searching."""
     queued = team_dao.get_queued_teams(guild_id)
     queued = sorted(queued, key=lambda t: t.get_rating(), reverse=True)
 
     if not queued:
-        desc = ("No teams are searching right now.\n\n"
-                "Captains: build a 4/4 roster with `/team_create`, `/team_add`, "
-                "then `/team_queue` to join the pool.")
+        desc = "No teams searching.\n\nCaptains: build a 4/4 roster with `/team_create` and `/team_add`, then click **Queue Up** below."
     else:
         rows = []
         for t in queued:
             sr = f"SR {int(t.team_sr)}" if t.is_ranked() else "Unranked"
             rows.append(f"{t.get_rank_emoji()} **{t.team_name}** — {sr} • {len(t.players)}/{MAX_TEAM_SIZE}")
-        desc = ("Teams searching for a match:\n\n" + "\n".join(rows) +
-                "\n\nAnyone can run `/team_start` to match the two closest teams.")
+        desc = f"{len(queued)} team(s) searching:\n\n" + "\n".join(rows)
 
-    return Embedding(title="🏟️ Team Queue Pool", desc=desc, color=TEAM_COLOR)
+    embed = Embedding(title="🏟️ Team Queue", desc=desc, color=TEAM_COLOR)
+    component = Components()
+    component.add_button("Queue Up", f"team_queue_join#{queue_id}", False, 1)
+    component.add_button("Dequeue", f"team_queue_leave#{queue_id}", False, 4)
+    component.add_button("Start Match", f"team_queue_start#{queue_id}", len(queued) < 2, 3)
+    return [embed], [component]
 
 
 # ---------------------------------------------------------------------------
@@ -192,6 +194,19 @@ def queue_team(guild_id: str, captain_id: str) -> Embedding:
     embed = build_team_lobby_embed(team)
     embed.add_field("Pool", f"{pool_size} team(s) searching. Run `/team_start` to match.", inline=False)
     return embed
+
+
+def dequeue_team(guild_id: str, captain_id: str) -> Embedding:
+    team = team_dao.get_team_by_player(guild_id, captain_id)
+    if team is None:
+        return _error(":x: No team", "You're not on a team.")
+    if team.captain_id != captain_id:
+        return _error(":x: Captain only", "Only the team captain can dequeue the team.")
+    if team.status != STATUS_QUEUED:
+        return _error(":x: Not searching", "Your team isn't currently searching for a match.")
+    team.status = STATUS_IDLE
+    team_dao.put_team(team)
+    return Embedding("✅ Dequeued", f"**{team.team_name}** is no longer searching.", color=TEAM_COLOR)
 
 
 # ---------------------------------------------------------------------------

--- a/dao/LeaderboardDao.py
+++ b/dao/LeaderboardDao.py
@@ -14,10 +14,13 @@ if os.environ.get('BOT_ENV') == "PROD":
   table_name = "GuildToLeaderboardMappingTableProd"
 
 class LeaderboardRecord:
-  def __init__(self, guild_id: str, leaderboard_channel_id: str, leaderboard_message_id: str, version: int):
+  def __init__(self, guild_id: str, leaderboard_channel_id: str, leaderboard_message_id: str, version: int,
+               team_leaderboard_channel_id: str = "", team_leaderboard_message_id: str = ""):
     self.guild_id = guild_id
     self.leaderboard_channel_id = leaderboard_channel_id
     self.leaderboard_message_id = leaderboard_message_id
+    self.team_leaderboard_channel_id = team_leaderboard_channel_id
+    self.team_leaderboard_message_id = team_leaderboard_message_id
     self.version = int(version)
 
 class LeaderboardDao:
@@ -62,5 +65,11 @@ class LeaderboardDao:
 
 
   def get_leaderboard_record_attributes(self, response):
-    return LeaderboardRecord(guild_id=response["guild_id"], leaderboard_message_id=response["leaderboard_message_id"],
-                             leaderboard_channel_id=response["leaderboard_channel_id"], version=response["version"])
+    return LeaderboardRecord(
+      guild_id=response["guild_id"],
+      leaderboard_message_id=response["leaderboard_message_id"],
+      leaderboard_channel_id=response["leaderboard_channel_id"],
+      version=response["version"],
+      team_leaderboard_channel_id=response.get("team_leaderboard_channel_id", ""),
+      team_leaderboard_message_id=response.get("team_leaderboard_message_id", ""),
+    )

--- a/dao/TeamDao.py
+++ b/dao/TeamDao.py
@@ -60,7 +60,7 @@ class TeamRecord:
     return len(self.players) >= MAX_TEAM_SIZE
 
   def is_ranked(self) -> bool:
-    return (self.tmw + self.tml) >= 10
+    return (self.tmw + self.tml) >= 1
 
   def calculate_proj_rank(self):
     hidden_mmr = self.get_rating() * 100
@@ -76,7 +76,7 @@ class TeamRecord:
     return max(RANK_SR_RANGES.keys())
 
   def get_rank_emoji(self):
-    if self.tmw + self.tml <= 9:
+    if self.tmw + self.tml == 0:
       return "<:recruit:1367977165618024491>"
     if self.team_rank == 0:
       return "<:Bronze:1367281599250563216>"
@@ -122,8 +122,8 @@ class TeamRecord:
       self.team_rank = self.calculate_sr_rank(new_sr)
       self.team_delta = str(int(float(new_sr - curr_sr)))
 
-    # Placement: on the 10th team game, seed rank from hidden MMR (capped at Diamond)
-    if self.tmw + self.tml == 10:
+    # Placement: after the 1st team game, seed rank from hidden MMR (capped at Diamond)
+    if self.tmw + self.tml == 1:
       placement_rank = max(self.team_rank, self.calculate_proj_rank())
       self.team_rank = min(3, placement_rank)
       self.team_sr = RANK_SR_RANGES[self.team_rank][0] + 50

--- a/tests/test_team_dao.py
+++ b/tests/test_team_dao.py
@@ -70,9 +70,9 @@ class TestTeamApplyRpChange:
         t.apply_rp_change(loss=1, expected=0.5)
         assert t.team_delta.startswith("-")
 
-    def test_placement_fires_on_10th_game(self):
-        # tmw=9, tml=0 → after the win is recorded externally we simulate total 10
-        t = _team(team_sr=50, team_rank=0, tmw=10, tml=0)
+    def test_placement_fires_on_1st_game(self):
+        # 1 game recorded before apply_rp_change is called (trueskill increments tmw first)
+        t = _team(team_sr=50, team_rank=0, tmw=1, tml=0)
         t.apply_rp_change(loss=0, expected=0.5)
         assert t.team_sr == RANK_SR_RANGES[t.team_rank][0] + 50
         assert t.team_rank <= 3
@@ -85,9 +85,9 @@ class TestTeamHelpers:
         assert t.is_full() is False
 
     def test_is_ranked_threshold(self):
-        assert _team(tmw=6, tml=4).is_ranked() is True   # 10 games
-        assert _team(tmw=5, tml=4).is_ranked() is False  # 9 games
+        assert _team(tmw=1, tml=0).is_ranked() is True   # 1 game
+        assert _team(tmw=0, tml=0).is_ranked() is False  # 0 games
 
     def test_recruit_emoji_before_placement(self):
-        t = _team(tmw=2, tml=3)
+        t = _team(tmw=0, tml=0)
         assert "recruit" in t.get_rank_emoji()

--- a/tests/test_team_match_completion.py
+++ b/tests/test_team_match_completion.py
@@ -31,6 +31,7 @@ def patched(mocker):
                       return_value=Embedding("done", "x", color=0x7c3aed))
     mocker.patch("core.TeamManager.complete_team_match")
     mocker.patch("core.TeamManager.cancel_team_match")
+    mocker.patch("core.TeamLeaderboardManager.post_team_leaderboard")
     return qd, ts, tm
 
 


### PR DESCRIPTION
## Summary

- **Interactive team queue pool**: `/queue <team-queue-name>` now renders a live embed with **Queue Up**, **Dequeue**, and **Start Match** buttons — same UX as the solo queue. The embed updates in-place on every action. Only the team captain can Queue Up or Dequeue (non-captains get an ephemeral error); anyone can click Start Match once ≥2 teams are searching.

- **Placement after 1 game**: Team rank and SR are assigned after the very first match instead of the 10th. Recruit emoji only shows for teams with 0 games played.

- **Team leaderboard auto-updates**: After every team match completes, `post_team_leaderboard()` deletes the old pinned message and posts a fresh one — identical pattern to the solo leaderboard. Channel is configured via the existing `GuildToLeaderboardMappingTable` with two new fields (`team_leaderboard_channel_id`, `team_leaderboard_message_id`; default `""` so existing rows are unaffected).

- **Cross-queue guard**: A captain cannot queue their team in the team pool if any team member is already in the solo queue lobby. The error names the blocking player. Players can still join the solo queue freely while on a team.

## Test plan

- [ ] Run `/queue <team-queue-name>` — see interactive embed with Queue Up / Dequeue / Start Match buttons
- [ ] Click **Queue Up** as captain — team appears in pool, Start Match enables at ≥2 teams
- [ ] Click **Queue Up** as non-captain — ephemeral error, embed unchanged
- [ ] Click **Queue Up** when a team member is in the solo queue — ephemeral error naming the player
- [ ] Click **Start Match** — Match Ready embed posted in channel, pool resets to empty
- [ ] Complete a team match — team leaderboard channel updates with fresh embed
- [ ] After first match, `/team_leaderboard` shows the team with rank and SR (not "10 games required")
- [ ] All 147 unit tests pass: `pytest tests/ -v`

https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw

---
_Generated by [Claude Code](https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw)_