### PR TITLE
Fix: team match inherits channels from pool record, not hardcoded queue 1

### DIFF
--- a/core/QueueManager.py
+++ b/core/QueueManager.py
@@ -736,11 +736,15 @@ def team_pool_start(inter: Interaction, queue_id: str, channel_id: str):
         )
         return None
     team_a, team_b = TM._pick_fairest_pair(queued)
-    base = queue_dao.get_queue_or_none(inter.guild_id, "1")
+    # Inherit channel config from the team pool record itself; fall back to the
+    # base solo queue "1" only if the pool record isn't channel-configured.
+    base = queue_dao.get_queue_or_none(inter.guild_id, queue_id)
+    if base is None or not base.result_channel_id:
+        base = queue_dao.get_queue_or_none(inter.guild_id, "1")
     if base is None:
         inter.send_followup(
             embeds=[Embedding(":x: Queue not set up",
-                              "No base queue `1` exists to inherit channels from.",
+                              f"No channel config found on queue `{queue_id}` or base queue `1`.",
                               color=0xFF0000)],
             ephemeral=True,
         )


### PR DESCRIPTION
## Summary

Follow-up to #70. Fixes the **"No base queue `1` exists to inherit channels from"** error when clicking **Start Match** in the team queue.

`team_pool_start` was hardcoded to copy channel config (result channel, team voice channels, map set) from a solo queue record named `1`. Guilds running the team queue without that record hit the error and couldn't start a match.

Now it reads channel config from the **team queue pool record itself** (the `is_team_queue` record loaded by `/queue <name>`), falling back to base queue `1` only when the pool record has no `result_channel_id`.

## Note for setup

For `Start Match` to fully work, the team pool record (or fallback queue `1`) must have `result_channel_id`, `team_1_channel_id`, `team_2_channel_id`, and `map_set` populated.

## Test plan

- [ ] Team pool record with channels set → Start Match posts Match Ready embed, moves players to team VCs
- [ ] Guild without queue `1` but with a configured pool record → Start Match works
- [ ] Neither configured → clear error naming both the pool queue and `1`
- [ ] All 147 unit tests pass: `pytest tests/ -v`

https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw

---
_Generated by [Claude Code](https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw)_