### PR TITLE
Delete team match lobby message on completion/cancel instead of editing it

### DIFF
--- a/core/QueueManager.py
+++ b/core/QueueManager.py
@@ -371,23 +371,25 @@ def team_1_won(inter: Interaction, queue_id: str):
 
 
 def _complete_team_match_result(inter: Interaction, response: QueueRecord, win_team_id: str, lose_team_id: str):
-    """Finish a team-queue match: update team ratings, post the result, return
-    both teams to idle, and clear the match record. Returns the embed/component
-    to edit the live Match Ready message into a completed view (so it doesn't
-    stay frozen on the old roster)."""
+    """Finish a team-queue match: update team ratings, post the result to the
+    results channel, return both teams to idle, and clear the match record.
+
+    The live Match Ready (lobby) message is deleted — the result already lands
+    in the results channel, so the lobby message just disappears. Returns None
+    so the caller skips any further edit of the (now-deleted) message."""
     import core.TeamManager as TeamManager
     from core import TeamLeaderboardManager
     ts.post_team_match(win_team_id=win_team_id, lose_team_id=lose_team_id, guild_id=inter.guild_id)
     done_embed = TeamManager.generate_team_match_done_embed(win_team_id, lose_team_id, inter.guild_id)
     inter.send_message(channel_id=response.result_channel_id, embeds=[done_embed])
     TeamManager.complete_team_match(inter.guild_id, win_team_id, lose_team_id)
+    # Delete the lobby message wherever it was posted.
+    for channel_id, message_id in response.channel_config.items():
+        inter.delete_message(message_id=message_id, channel_id=channel_id)
     response.clear_queue(reset_expiry=False)
     queue_dao.put_queue(response)
     TeamLeaderboardManager.post_team_leaderboard(inter.guild_id, inter)
-    # No buttons on the completed view — the match is over. Return an empty
-    # components list (not [Components()]) so the action row is removed; an
-    # action row with zero buttons is rejected by Discord with a 400.
-    return [done_embed], []
+    return None
 
 
 def team_2_won(inter: Interaction, queue_id: str):
@@ -488,10 +490,12 @@ def cancel_match(inter: Interaction, queue_id: str):
             if getattr(response, "is_team_queue", False):
                 import core.TeamManager as TeamManager
                 TeamManager.cancel_team_match(inter.guild_id, response.team_1_id, response.team_2_id)
+                # Match ended → the lobby message just disappears (no result post).
+                for channel_id, message_id in response.channel_config.items():
+                    inter.delete_message(message_id=message_id, channel_id=channel_id)
                 response.clear_queue(reset_expiry=False)
                 queue_dao.put_queue(response)
-                cancelled = Embedding("🚫 Team Match Cancelled", "Both teams have been returned to idle.", color=0xFF0000)
-                return [cancelled], []
+                return None
             response.clear_queue(reset_expiry=False)
             promote_waitlist(response)
             resp = queue_dao.put_queue(response)

--- a/tests/test_team_match_completion.py
+++ b/tests/test_team_match_completion.py
@@ -1,5 +1,7 @@
-"""Regression tests: a completed/cancelled team match must return a fresh view
-so the live Match Ready message updates instead of freezing on the old roster."""
+"""Regression tests: a completed/cancelled team match deletes the live Match
+Ready (lobby) message and returns None — the result is already posted to the
+results channel, so the lobby message just disappears instead of being edited
+into a redundant completed view."""
 
 import pytest
 from unittest.mock import MagicMock
@@ -43,28 +45,30 @@ def _inter(user_id="a4"):
     return inter
 
 
-def test_team_win_returns_completed_view_not_none(patched):
+def test_team_win_deletes_lobby_and_returns_none(patched):
     qd, ts, tm = patched
     # 4 votes already; this is the deciding 5th vote.
     record = _team_match_record(team1_votes=["a1", "a2", "a3", "b1"])
     qd.get_queue.return_value = record
+    inter = _inter("a4")
 
-    result = QueueManager.team_1_won(_inter("a4"), "TEAM-abc123")
+    result = QueueManager.team_1_won(inter, "TEAM-abc123")
 
-    assert result is not None, "completion must return a view so the message updates"
-    embeds, components = result
-    assert len(embeds) == 1
+    assert result is None, "completion deletes the lobby message; nothing left to edit"
     ts.post_team_match.assert_called_once()
+    # Result posted to the results channel, lobby message deleted.
+    inter.send_message.assert_called_once()
+    inter.delete_message.assert_called_once_with(message_id="msg", channel_id="ch")
 
 
-def test_team_cancel_returns_cancelled_view_not_none(patched):
+def test_team_cancel_deletes_lobby_and_returns_none(patched):
     qd, ts, tm = patched
     # Match ready needs 5 cancel votes; supply 4 prior + this one.
     record = _team_match_record(cancel_votes=["a1", "a2", "a3", "b1"])
     qd.get_queue.return_value = record
+    inter = _inter("a4")
 
-    result = QueueManager.cancel_match(_inter("a4"), "TEAM-abc123")
+    result = QueueManager.cancel_match(inter, "TEAM-abc123")
 
-    assert result is not None
-    embeds, components = result
-    assert "Cancel" in embeds[0].title or "ancel" in embeds[0].title
+    assert result is None, "cancel deletes the lobby message; nothing left to edit"
+    inter.delete_message.assert_called_once_with(message_id="msg", channel_id="ch")


### PR DESCRIPTION
## Summary

Follow-up to #72. When a team match ends, the Match Ready (lobby) message was edited into a "Team Match Completed" embed — but the result is **already** posted to the results channel, so that was a redundant duplicate.

Now the lobby message simply **disappears**:

- **Win** (deciding vote): result posts to the results channel → lobby message deleted
- **Cancel** (cancel threshold reached): both teams returned to idle → lobby message deleted (no results post, since it was cancelled)

Both completion and cancel handlers now return `None`, so the caller skips editing a message that no longer exists. This also fully sidesteps the empty-action-row 400 path.

## Test plan

- [ ] Cast the deciding win vote → result appears in results channel, lobby message vanishes
- [ ] Reach cancel threshold → teams return to idle, lobby message vanishes
- [ ] Updated regression tests assert the lobby message is deleted (`delete_message` called) and `team_1_won` / `cancel_match` return `None`
- [ ] All 147 unit tests pass: `pytest tests/ -v`

https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw

---
_Generated by [Claude Code](https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw)_