### PR TITLE
Captain-priority voting: both captains agreeing triggers match immediately

### DIFF
--- a/core/QueueManager.py
+++ b/core/QueueManager.py
@@ -345,7 +345,10 @@ def team_1_won(inter: Interaction, queue_id: str):
     resp = queue_dao.put_queue(response)
 
     if resp is not None:
-        if len(response.team1_votes) == 5:
+        threshold_met = (len(response.team1_votes) == 5 or
+                         (getattr(response, "is_team_queue", False) and
+                          _both_captains_voted(response, response.team1_votes)))
+        if threshold_met:
             print(f"Posting team 1 win: {response.team_1} and team 2 lose: {response.team_2}")
             response = queue_dao.get_queue(guild_id=inter.guild_id, queue_id=queue_id)
             if getattr(response, "is_team_queue", False):
@@ -368,6 +371,17 @@ def team_1_won(inter: Interaction, queue_id: str):
 
         return embed, component
     return None
+
+
+def _both_captains_voted(response: QueueRecord, vote_list: list) -> bool:
+    """Return True if both team captains appear in vote_list."""
+    from dao.TeamDao import TeamDao
+    team_dao = TeamDao()
+    t1 = team_dao.get_team(response.guild_id, response.team_1_id)
+    t2 = team_dao.get_team(response.guild_id, response.team_2_id)
+    if t1 is None or t2 is None:
+        return False
+    return t1.captain_id in vote_list and t2.captain_id in vote_list
 
 
 def _complete_team_match_result(inter: Interaction, response: QueueRecord, win_team_id: str, lose_team_id: str):
@@ -409,7 +423,10 @@ def team_2_won(inter: Interaction, queue_id: str):
     resp = queue_dao.put_queue(response)
 
     if resp is not None:
-        if len(response.team2_votes) == 5:
+        threshold_met = (len(response.team2_votes) == 5 or
+                         (getattr(response, "is_team_queue", False) and
+                          _both_captains_voted(response, response.team2_votes)))
+        if threshold_met:
             print(f"Posting team 1 lose: {response.team_1} and team 2 win: {response.team_2}")
             response = queue_dao.get_queue(guild_id=inter.guild_id, queue_id=queue_id)
             if getattr(response, "is_team_queue", False):
@@ -485,7 +502,10 @@ def cancel_match(inter: Interaction, queue_id: str):
             cancel_threshold = 5
         else:
             cancel_threshold = len(response.queue) // 2
-        if len(response.cancel_votes) >= cancel_threshold:
+        captain_override = (is_match_ready and
+                            getattr(response, "is_team_queue", False) and
+                            _both_captains_voted(response, response.cancel_votes))
+        if len(response.cancel_votes) >= cancel_threshold or captain_override:
             response = queue_dao.get_queue(guild_id=inter.guild_id, queue_id=queue_id)
             if getattr(response, "is_team_queue", False):
                 import core.TeamManager as TeamManager

--- a/tests/test_team_match_completion.py
+++ b/tests/test_team_match_completion.py
@@ -72,3 +72,72 @@ def test_team_cancel_deletes_lobby_and_returns_none(patched):
 
     assert result is None, "cancel deletes the lobby message; nothing left to edit"
     inter.delete_message.assert_called_once_with(message_id="msg", channel_id="ch")
+
+
+def _mock_team_captains(mocker, t1_captain="a1", t2_captain="b1"):
+    MockTeamDao = mocker.patch("dao.TeamDao.TeamDao")
+    inst = MockTeamDao.return_value
+    t1 = MagicMock(); t1.captain_id = t1_captain
+    t2 = MagicMock(); t2.captain_id = t2_captain
+    inst.get_team.side_effect = lambda guild_id, team_id: (
+        t1 if team_id == "TID1" else t2
+    )
+    return inst
+
+
+def test_captain_priority_team1_win_triggers_with_two_votes(patched, mocker):
+    qd, ts, tm = patched
+    # Only team 1 captain (a1) has voted so far; team 2 captain (b1) votes now.
+    record = _team_match_record(team1_votes=["a1"])
+    qd.get_queue.return_value = record
+    _mock_team_captains(mocker, t1_captain="a1", t2_captain="b1")
+    inter = _inter("b1")
+
+    result = QueueManager.team_1_won(inter, "TEAM-abc123")
+
+    assert result is None, "both captains agreed — match should complete immediately"
+    ts.post_team_match.assert_called_once()
+    inter.delete_message.assert_called_once_with(message_id="msg", channel_id="ch")
+
+
+def test_captain_priority_team2_win_triggers_with_two_votes(patched, mocker):
+    qd, ts, tm = patched
+    # Only team 1 captain has voted (for team 2); team 2 captain also votes.
+    record = _team_match_record(team2_votes=["a1"])
+    qd.get_queue.return_value = record
+    _mock_team_captains(mocker, t1_captain="a1", t2_captain="b1")
+    inter = _inter("b1")
+
+    result = QueueManager.team_2_won(inter, "TEAM-abc123")
+
+    assert result is None, "both captains agreed — match should complete immediately"
+    ts.post_team_match.assert_called_once()
+    inter.delete_message.assert_called_once_with(message_id="msg", channel_id="ch")
+
+
+def test_captain_priority_cancel_triggers_with_two_votes(patched, mocker):
+    qd, ts, tm = patched
+    # Team 1 captain already voted to cancel; team 2 captain votes now.
+    record = _team_match_record(cancel_votes=["a1"])
+    qd.get_queue.return_value = record
+    _mock_team_captains(mocker, t1_captain="a1", t2_captain="b1")
+    inter = _inter("b1")
+
+    result = QueueManager.cancel_match(inter, "TEAM-abc123")
+
+    assert result is None, "both captains agreed to cancel — should complete immediately"
+    inter.delete_message.assert_called_once_with(message_id="msg", channel_id="ch")
+
+
+def test_single_captain_vote_does_not_trigger(patched, mocker):
+    qd, ts, tm = patched
+    # Only one captain voted; the other has not — should NOT trigger.
+    record = _team_match_record(team1_votes=[])
+    qd.get_queue.return_value = record
+    _mock_team_captains(mocker, t1_captain="a1", t2_captain="b1")
+    inter = _inter("a1")  # only team-1 captain votes
+
+    result = QueueManager.team_1_won(inter, "TEAM-abc123")
+
+    assert result is not None, "only one captain voted — should not trigger completion"
+    ts.post_team_match.assert_not_called()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- If both team captains vote for the same outcome (Team 1 Won, Team 2 Won, or Cancel), the match completes immediately — no need for 5 total votes
- Adds `_both_captains_voted(response, vote_list)` helper in `core/QueueManager.py` that looks up both `TeamRecord`s and checks if both captains' IDs appear in the given vote list
- The 5-vote threshold is kept; `_both_captains_voted` is only called when the threshold hasn't already been met (short-circuit OR)

## Test plan

- [ ] `test_captain_priority_team1_win_triggers_with_two_votes` — team 1 captain + team 2 captain both vote team-1-win → completes with 2 votes
- [ ] `test_captain_priority_team2_win_triggers_with_two_votes` — same for team-2-win
- [ ] `test_captain_priority_cancel_triggers_with_two_votes` — both captains vote cancel → lobby deleted with 2 votes
- [ ] `test_single_captain_vote_does_not_trigger` — only one captain voted → no trigger, embed returned
- [ ] All 151 suite tests pass

https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012G6butKtHm3HGTMAffwWBw)_