### PR TITLE
Track bracket championship wins; show trophies on leaderboard

### DIFF
--- a/core/BracketManager.py
+++ b/core/BracketManager.py
@@ -782,6 +782,13 @@ def _finish_tournament(inter: Interaction, meta: QueueRecord, meta_bracket: dict
     meta_bracket["champion"] = champion
     queue_dao.put_queue(meta)
 
+    # Increment championship count for every player on the winning team.
+    for pid in champion:
+        p = player_dao.get_player(guild_id=inter.guild_id, player_id=pid)
+        if p:
+            p.championships = int(p.championships) + 1
+            player_dao.put_player(p)
+
     embed = _champion_embed(champion, inter.guild_id, meta.tournament_id)
     inter.send_message(channel_id=meta_bracket["result_channel_id"], embeds=[embed])
 

--- a/core/LeaderboardManager.py
+++ b/core/LeaderboardManager.py
@@ -46,7 +46,8 @@ def build_leaderboard_entries(guild_id: str):
             "delta": delta,
             "wins": wins,
             "losses": losses,
-            "total": total_games
+            "total": total_games,
+            "championships": int(getattr(user, "championships", 0)),
         }
         entries.append(entry)
         rank += 1
@@ -67,8 +68,10 @@ def build_leaderboard_page(guild_id: str, page: int):
     rows = []
     for entry in page_entries:
         streak = f" {entry['streak_emoji']}" if entry['streak_emoji'] else ""
+        champs = entry.get("championships", 0)
+        trophy_str = f" 🏆x{champs}" if champs > 0 else ""
         row = (
-            f"{entry['medal']} {entry['rank_emoji']} **{entry['name']}**{streak}\n"
+            f"{entry['medal']} {entry['rank_emoji']} **{entry['name']}**{streak}{trophy_str}\n"
             f"└─ SR: **{entry['sr']}** ({entry['delta']}) | {entry['wins']}W / {entry['losses']}L"
         )
         rows.append(row)

--- a/dao/PlayerDao.py
+++ b/dao/PlayerDao.py
@@ -43,7 +43,7 @@ RANK_SR_RANGES = {
 
 
 class PlayerRecord:
-  def __init__(self, guild_id: str, player_id: str, player_name: str, mw: int = 0, ml: int = 0, sr: float = 0.0, rank: int = 0, elo: float = 25.0, sigma: float = 8.33, delta: str = "+0.0", streak: int = 0, version: int = 0, last_played: int = 0, last_loss_forgiven: int = 0):
+  def __init__(self, guild_id: str, player_id: str, player_name: str, mw: int = 0, ml: int = 0, sr: float = 0.0, rank: int = 0, elo: float = 25.0, sigma: float = 8.33, delta: str = "+0.0", streak: int = 0, version: int = 0, last_played: int = 0, last_loss_forgiven: int = 0, championships: int = 0):
     self.guild_id = guild_id
     self.player_id = player_id
     self.player_name = player_name
@@ -58,6 +58,7 @@ class PlayerRecord:
     self.version = version
     self.last_played = int(last_played)
     self.last_loss_forgiven = int(last_loss_forgiven)
+    self.championships = int(championships)
 
 
   def get_streak(self):
@@ -260,4 +261,5 @@ class PlayerDao:
       last_loss_forgiven = 0
       if response.get("last_loss_forgiven") is not None:
         last_loss_forgiven = int(response["last_loss_forgiven"])
-      return PlayerRecord(player_id=response["player_id"], player_name=response['player_name'], guild_id=response["guild_id"], mw=response["mw"], ml=response["ml"], sr=sr, rank=rank, elo=response["elo"], sigma=response["sigma"], delta=response["delta"], streak=response["streak"], version=response["version"], last_played=last_played, last_loss_forgiven=last_loss_forgiven)
+      championships = int(response.get("championships", 0))
+      return PlayerRecord(player_id=response["player_id"], player_name=response['player_name'], guild_id=response["guild_id"], mw=response["mw"], ml=response["ml"], sr=sr, rank=rank, elo=response["elo"], sigma=response["sigma"], delta=response["delta"], streak=response["streak"], version=response["version"], last_played=last_played, last_loss_forgiven=last_loss_forgiven, championships=championships)


### PR DESCRIPTION
## Summary

- Adds a `championships` field to `PlayerRecord` — incremented for each player on the winning team when a double-elimination bracket finishes.
- The leaderboard now shows a trophy indicator (e.g. `🏆x2`) next to any player who has won one or more brackets.
- Existing players without the field default to `0` via `.get("championships", 0)` in the deserializer — no migration needed.

## Changes

**`dao/PlayerDao.py`** — `championships: int = 0` added to `PlayerRecord.__init__`; deserializer reads it defensively with `.get()`.

**`core/BracketManager.py`** — `_finish_tournament` increments `championships` for each player on the winning team before posting the champion embed.

**`core/LeaderboardManager.py`** — leaderboard rows append `🏆x2` (or however many) after the player name, only when `championships > 0`.

## Test plan

- [ ] Deploy to `dev`
- [ ] Complete a bracket tournament → confirm each winning player's `championships` increments in DynamoDB
- [ ] Check the leaderboard — trophy count should appear next to winners' names
- [ ] Confirm players with no championships show no trophy indicator
- [ ] Confirm players not yet on the leaderboard (< 10 games) are unaffected

https://claude.ai/code/session_01KPPiEFcPyArGp1PdPnsVap

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPPiEFcPyArGp1PdPnsVap)_