### PR TITLE
Fix /bracket_cancel double-defer crash

### DIFF
--- a/commands/bracket_cancel.py
+++ b/commands/bracket_cancel.py
@@ -3,7 +3,6 @@ from discord_lambda import CommandRegistry, Interaction, CommandArg, Embedding
 
 
 def bracket_cancel(inter: Interaction, queue_name: str) -> None:
-    inter.defer(ephemeral=True)
     msg = BracketManager.cancel_bracket(inter, queue_name)
     inter.send_response(
         embeds=[Embedding(desc=msg, color=0x00C853 if "check_mark" in msg else 0xFF0000)],


### PR DESCRIPTION
## Summary

- Removes the redundant `inter.defer(ephemeral=True)` call from `bracket_cancel`. `lambda_function.py` already calls `interaction.defer()` for all slash commands (type 2) before the command function runs — a second defer POST to the callback URL causes Discord to return an error, surfacing as "unable to defer response".

## Test plan

- [ ] `/bracket_cancel <queue>` with active bracket → ephemeral confirmation, no "unable to defer response" error

https://claude.ai/code/session_01KPPiEFcPyArGp1PdPnsVap

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPPiEFcPyArGp1PdPnsVap)_