### PR TITLE
Fix Decimal serialization crash in bracket operations

### DIFF
--- a/commands/bracket_cancel.py
+++ b/commands/bracket_cancel.py
@@ -6,7 +6,7 @@ def bracket_cancel(inter: Interaction, queue_name: str) -> None:
     msg = BracketManager.cancel_bracket(inter, queue_name)
     inter.send_response(
         embeds=[Embedding(desc=msg, color=0x00C853 if "check_mark" in msg else 0xFF0000)],
-        ephemeral=True,
+        ephemeral=False,
     )
 
 

--- a/dao/__init__.py
+++ b/dao/__init__.py
@@ -10,4 +10,7 @@ class DecimalEncoder(json.JSONEncoder):
 def set_default(obj):
   if isinstance(obj, set):
     return list(obj)
+  if isinstance(obj, decimal.Decimal):
+    # DynamoDB returns all numbers as Decimal; convert to int when lossless, else float
+    return int(obj) if obj == int(obj) else float(obj)
   raise TypeError


### PR DESCRIPTION
## Summary

- **Root cause of "request can't be completed ''"**: `set_default` in `dao/__init__.py` raised `TypeError` with no arguments for any unhandled type. DynamoDB returns every number as `Decimal` when reading records back, so any bracket operation that reads then re-writes the meta `QueueRecord` (voting, match advancement, cancel) would crash with `TypeError()` — whose `str()` is `""` — showing as empty backticks in the error embed.
- Fixed `set_default` to convert `Decimal` to `int` (when lossless) or `float`, matching the pattern `DecimalEncoder` already uses for player records.
- Also fixes the ephemeral mismatch in `/bracket_cancel`: `send_response` now uses `ephemeral=False` to match the public defer in `lambda_function.py`.

## Test plan

- [ ] `/bracket_cancel <queue>` with active bracket → shows confirmation, no crash
- [ ] Vote on a bracket match → vote count updates, match advances when threshold met, no crash
- [ ] Grand final completes → champion embed posts, trophies increment on leaderboard

https://claude.ai/code/session_01KPPiEFcPyArGp1PdPnsVap

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPPiEFcPyArGp1PdPnsVap)_