### PR TITLE
Increase queue expiry timeout from 10 to 20 minutes

### DIFF
--- a/dao/QueueDao.py
+++ b/dao/QueueDao.py
@@ -70,7 +70,7 @@ class QueueRecord:
       self.update_expiry_date()
 
   def update_expiry_date(self):
-    time = datetime.utcnow() + timedelta(minutes=10)
+    time = datetime.utcnow() + timedelta(minutes=20)
     self.expiry = int(time.timestamp())
 
 class QueueDao:


### PR DESCRIPTION
## Summary

- `QueueRecord.update_expiry_date` now sets expiry to 20 minutes from now instead of 10.

## Test plan

- [ ] Join a queue, wait 10+ minutes, verify the queue embed is still active and doesn't reset until 20 minutes have passed

https://claude.ai/code/session_01KPPiEFcPyArGp1PdPnsVap

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPPiEFcPyArGp1PdPnsVap)_