### PR TITLE
Fix waitlist bugs: dead error path, match players joining, wrong error messages

### DIFF
--- a/core/ButtonManager.py
+++ b/core/ButtonManager.py
@@ -109,6 +109,10 @@ def join_waitlist_button(guild_id: str, inter: Interaction):
     inter.send_followup(embeds=[error_embed], ephemeral=True)
     return
 
+  if resp == "handled":
+    # add_waitlist_player already sent a specific error followup
+    return
+
   (embed, component) = resp
 
   record = queue_dao.get_queue(guild_id=guild_id, queue_id=inter.custom_id.split("#")[1])

--- a/core/QueueManager.py
+++ b/core/QueueManager.py
@@ -107,14 +107,29 @@ def add_waitlist_player(inter: Interaction, queue_id: str):
         print("Cannot join waitlist: game not in Match Ready state")
         return None
 
-    # Enforce waitlist capacity and deduplication
-    if len(response.waitlist) >= MAX_QUEUE_SIZE:
-        print(f"Waitlist full ({MAX_QUEUE_SIZE} players)")
-        return None
+    # Players already in the match cannot also join the waitlist
+    if inter.user_id in response.team_1 or inter.user_id in response.team_2:
+        inter.send_followup(
+            embeds=[Embedding(":x: Cannot Join Waitlist", "You are already playing in this match.", color=0xFF0000)],
+            ephemeral=True,
+        )
+        return "handled"
 
+    # Enforce waitlist capacity
+    if len(response.waitlist) >= MAX_QUEUE_SIZE:
+        inter.send_followup(
+            embeds=[Embedding(":x: Waitlist Full", f"The waitlist is full ({MAX_QUEUE_SIZE} players).", color=0xFF0000)],
+            ephemeral=True,
+        )
+        return "handled"
+
+    # Deduplication
     if inter.user_id in response.waitlist:
-        print(f"Player {inter.user_id} already in waitlist")
-        return None
+        inter.send_followup(
+            embeds=[Embedding(":x: Already in Waitlist", "You are already in the waitlist.", color=0xFF0000)],
+            ephemeral=True,
+        )
+        return "handled"
 
     # Register player if not already registered
     player_data = player_dao.get_player(guild_id=inter.guild_id, player_id=inter.user_id)
@@ -134,9 +149,10 @@ def add_waitlist_player(inter: Interaction, queue_id: str):
 def remove_waitlist_player(inter: Interaction, queue_id: str):
     response = queue_dao.get_queue(guild_id=inter.guild_id, queue_id=queue_id)
 
-    if inter.user_id in response.waitlist:
-        response.waitlist.remove(inter.user_id)
+    if inter.user_id not in response.waitlist:
+        return None  # triggers "Not in Waitlist" error in ButtonManager
 
+    response.waitlist.remove(inter.user_id)
     resp = queue_dao.put_queue(response)
 
     if resp is not None:


### PR DESCRIPTION
## Bugs fixed

**1. "Leave Waitlist" never showed an error (dead code)**
`remove_waitlist_player` was calling `put_queue` and returning an embed even when the player was not in the waitlist. The "Not in Waitlist" error in `ButtonManager` was unreachable dead code — it only triggered on DynamoDB OCC failures, not on the actual "not in list" case. Fixed with an early `return None` guard.

**2. Match players could join the waitlist**
Players already assigned to `team_1` or `team_2` could also click "Join Waitlist". This caused them to appear in both the team section and the waitlist section of the embed, and they'd be auto-requeued for the next match immediately after finishing the one they just played. Added a guard that blocks this and sends a specific ephemeral error: *"You are already playing in this match."*

**3. Wrong error messages for waitlist-full and already-in-waitlist cases**
Both cases returned `None`, which made `ButtonManager` show the generic *"You can only join the waitlist when a match is ready and in progress"* message — misleading when the match IS ready but the player is full or already queued. These cases now send their own specific error messages via `send_followup` and return a `"handled"` sentinel so `ButtonManager` skips the generic fallback.

## Test plan

- [ ] Click "Join Waitlist" with no active match → *"match is ready and in progress"* error
- [ ] Click "Join Waitlist" while in `team_1` or `team_2` → *"already playing in this match"* error
- [ ] Click "Join Waitlist" twice → *"already in the waitlist"* error on second click
- [ ] Click "Leave Waitlist" when not in the waitlist → *"Not in Waitlist"* error
- [ ] Normal join/leave waitlist flow → embed updates correctly, promoted to queue when match ends

https://claude.ai/code/session_01KPPiEFcPyArGp1PdPnsVap

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPPiEFcPyArGp1PdPnsVap)_